### PR TITLE
Double grid resolution and read size from file

### DIFF
--- a/src/testcase1/plot_snapshots.py
+++ b/src/testcase1/plot_snapshots.py
@@ -3,9 +3,17 @@ import os
 import numpy as np
 import matplotlib.pyplot as plt
 
-# Grid parameters must match the Fortran code
-nlon = 64
-nlat = 32
+
+def read_grid_params(fname="grid_params.txt"):
+    """Return grid dimensions (nlon, nlat) read from a text file."""
+    with open(fname) as f:
+        parts = f.read().split()
+    if len(parts) < 2:
+        raise ValueError(f"{fname} must contain at least two integers")
+    return int(parts[0]), int(parts[1])
+
+
+nlon, nlat = read_grid_params()
 dt = 600.0
 
 # Construct longitude/latitude arrays in degrees

--- a/src/testcase1/shallow_water_test1.f90
+++ b/src/testcase1/shallow_water_test1.f90
@@ -3,7 +3,7 @@ program shallow_water_test1
   ! Shallow water equation solver for cosine bell advection test case
   integer, parameter :: dp=kind(1.0d0)
   integer, parameter :: sp=kind(1.0)
-  integer, parameter :: nlon=64, nlat=32
+  integer, parameter :: nlon=128, nlat=64
   real(dp), parameter :: pi=3.14159265358979323846d0
   real(dp), parameter :: radius=6371220.d0, g=9.80616d0
   real(dp), parameter :: day=86400.d0
@@ -12,7 +12,7 @@ program shallow_water_test1
   real(dp), parameter :: omega=2.d0*pi/(12.d0*day)
   real(dp), parameter :: dt=600.d0
   integer, parameter :: nsteps=nint(12.d0*day/dt)
-  integer, parameter :: output_interval=24
+  integer, parameter :: output_interval=48
   real(dp) :: lon(nlon), lat(nlat)
   real(dp) :: h(nlon,nlat), hn(nlon,nlat)
   real(dp) :: ha(nlon,nlat)
@@ -31,6 +31,11 @@ program shallow_water_test1
      alpha = 0.d0
   end if
   alpha = alpha*pi/180.d0
+
+  ! Write grid dimensions for use by plotting script
+  open(unit=30,file='grid_params.txt',status='replace')
+  write(30,*) nlon, nlat
+  close(30)
 
   do i=1,nlon
      lon(i) = (i-0.5d0)*dlon


### PR DESCRIPTION
## Summary
- Double the simulation grid to 128x64 and halve snapshot frequency
- Write grid dimensions to `grid_params.txt` and read them in plotting script

## Testing
- `make clean && make`
- `./shallow_water_test1`
- `MPLBACKEND=Agg python plot_snapshots.py`


------
https://chatgpt.com/codex/tasks/task_b_688cbdb79778832db86d10b24c041185