### PR TITLE
Refactor solver into modular structure

### DIFF
--- a/src/common/constants_module.f90
+++ b/src/common/constants_module.f90
@@ -1,0 +1,6 @@
+module constants_module
+  implicit none
+  integer, parameter :: dp = kind(1.0d0)
+  integer, parameter :: sp = kind(1.0)
+end module constants_module
+

--- a/src/common/equations_module.f90
+++ b/src/common/equations_module.f90
@@ -1,0 +1,141 @@
+module equations_module
+  use constants_module, only: dp
+  use variables_module, only: nlon, nlat, pi, radius, dlon, dlat, h0, h1, omega
+  implicit none
+contains
+  subroutine init_height(h, lon, lat)
+    real(dp), intent(out) :: h(nlon,nlat)
+    real(dp), intent(in) :: lon(nlon), lat(nlat)
+    real(dp) :: lambda0, phi0, r0, dist
+    integer :: i,j
+    lambda0 = 3.d0*pi/2.d0
+    phi0 = 0.d0
+    r0 = radius/3.d0
+    do j=1,nlat
+       do i=1,nlon
+          h(i,j) = h0
+          call gc_distance(lon(i),lat(j),lambda0,phi0,dist)
+          if (dist < r0) then
+             h(i,j) = h0 + 0.5d0*h1*(1.d0+cos(pi*dist/r0))
+          end if
+       end do
+    end do
+  end subroutine init_height
+
+  subroutine velocity_field(u,v,lon,lat,alpha)
+    real(dp), intent(out) :: u(nlon+1,nlat), v(nlon,nlat+1)
+    real(dp), intent(in) :: lon(nlon), lat(nlat), alpha
+    real(dp) :: u0, lon_edge
+    integer :: i,j
+    u0 = omega*radius
+    do j=1,nlat
+       do i=1,nlon+1
+          lon_edge = (i-1)*dlon
+          u(i,j) = u0*(cos(lat(j))*cos(alpha) + sin(lat(j))*cos(lon_edge)*sin(alpha))
+       end do
+    end do
+    do j=1,nlat+1
+       do i=1,nlon
+          v(i,j) = -u0*sin(lon(i))*sin(alpha)
+       end do
+    end do
+    v(:,1) = 0.d0
+    v(:,nlat+1) = 0.d0
+  end subroutine velocity_field
+
+  subroutine analytic_height(ha, lon, lat, t, alpha)
+    real(dp), intent(out) :: ha(nlon,nlat)
+    real(dp), intent(in) :: lon(nlon), lat(nlat), t, alpha
+    real(dp) :: lonr, latr, theta
+    integer :: i,j
+    theta = -omega*t
+    do j=1,nlat
+       do i=1,nlon
+          call rotate_point(lon(i),lat(j),alpha,theta,lonr,latr)
+          ha(i,j) = initial_at_point(lonr,latr)
+       end do
+    end do
+  end subroutine analytic_height
+
+  function initial_at_point(lon,lat) result(hp)
+    real(dp), intent(in) :: lon, lat
+    real(dp) :: hp, lambda0, phi0, r0, dist
+    lambda0 = 3.d0*pi/2.d0
+    phi0 = 0.d0
+    r0 = radius/3.d0
+    hp = h0
+    call gc_distance(lon,lat,lambda0,phi0,dist)
+    if (dist < r0) hp = h0 + 0.5d0*h1*(1.d0+cos(pi*dist/r0))
+  end function initial_at_point
+
+  subroutine gc_distance(lon1,lat1,lon2,lat2,dist)
+    real(dp), intent(in) :: lon1,lat1,lon2,lat2
+    real(dp), intent(out) :: dist
+    dist = radius*acos( sin(lat1)*sin(lat2) + cos(lat1)*cos(lat2)*cos(lon1-lon2) )
+  end subroutine gc_distance
+
+  subroutine rotate_point(lon,lat,alpha,theta,lonp,latp)
+    real(dp), intent(in) :: lon, lat, alpha, theta
+    real(dp), intent(out) :: lonp, latp
+    real(dp) :: x,y,z,xp,yp,zp
+    real(dp) :: n1,n2,n3,dot,c1,c2,c3,ct,st
+    x = cos(lat)*cos(lon)
+    y = cos(lat)*sin(lon)
+    z = sin(lat)
+    n1 = -sin(alpha)
+    n2 = 0.d0
+    n3 = cos(alpha)
+    ct = cos(theta)
+    st = sin(theta)
+    dot = n1*x + n2*y + n3*z
+    c1 = n2*z - n3*y
+    c2 = n3*x - n1*z
+    c3 = n1*y - n2*x
+    xp = x*ct + c1*st + n1*dot*(1.d0-ct)
+    yp = y*ct + c2*st + n2*dot*(1.d0-ct)
+    zp = z*ct + c3*st + n3*dot*(1.d0-ct)
+    lonp = atan2(yp,xp)
+    if (lonp < 0.d0) lonp = lonp + 2.d0*pi
+    latp = asin(zp)
+  end subroutine rotate_point
+
+  subroutine rhs(h,dhdt,u,v,lat)
+    real(dp), intent(in) :: h(nlon,nlat), u(nlon+1,nlat), v(nlon,nlat+1), lat(nlat)
+    real(dp), intent(out) :: dhdt(nlon,nlat)
+    integer :: i,j,ip1,im1,jp1,jm1
+    real(dp) :: fe,fw,fn,fs,ue,uw,vn,vs
+    do j=1,nlat
+       jp1 = min(j+1,nlat)
+       jm1 = max(j-1,1)
+       do i=1,nlon
+          ip1 = mod(i,nlon)+1
+          im1 = mod(i-2+nlon,nlon)+1
+          ue = u(i+1,j)
+          uw = u(i,j)
+          if (ue > 0.d0) then
+             fe = ue*h(i,j)
+          else
+             fe = ue*h(ip1,j)
+          end if
+          if (uw > 0.d0) then
+             fw = uw*h(im1,j)
+          else
+             fw = uw*h(i,j)
+          end if
+          vn = v(i,j+1)
+          vs = v(i,j)
+          if (vn > 0.d0) then
+             fn = vn*h(i,j)
+          else
+             fn = vn*h(i,jp1)
+          end if
+          if (vs > 0.d0) then
+             fs = vs*h(i,jm1)
+          else
+             fs = vs*h(i,j)
+          end if
+          dhdt(i,j) = -((fe - fw)/(dlon*radius*cos(lat(j))) + (fn - fs)/(dlat*radius))
+       end do
+    end do
+  end subroutine rhs
+end module equations_module

--- a/src/common/io_module.f90
+++ b/src/common/io_module.f90
@@ -1,0 +1,56 @@
+module io_module
+  use constants_module, only: dp, sp
+  use variables_module, only: nlon, nlat, day, pi, h, u, v, hsp, usp, vsp
+  implicit none
+contains
+  subroutine read_alpha(alpha)
+    real(dp), intent(out) :: alpha
+    character(len=32) :: carg
+    if (command_argument_count() >= 1) then
+       call get_command_argument(1,carg)
+       read(carg,*) alpha
+    else
+       alpha = 0.d0
+    end if
+    alpha = alpha*pi/180.d0
+  end subroutine read_alpha
+
+  subroutine write_grid_params()
+    open(unit=30,file='grid_params.txt',status='replace')
+    write(30,*) nlon, nlat
+    close(30)
+  end subroutine write_grid_params
+
+  subroutine open_error_file()
+    open(unit=10,file='error.dat',status='replace')
+  end subroutine open_error_file
+
+  subroutine write_error(t,l1err,l2err,maxerr)
+    real(dp), intent(in) :: t, l1err, l2err, maxerr
+    write(10,'(f10.4,3(1x,e14.6))') t/day, l1err, l2err, maxerr
+  end subroutine write_error
+
+  subroutine close_error_file()
+    close(10)
+  end subroutine close_error_file
+
+  subroutine write_snapshot(n)
+    integer, intent(in) :: n
+    character(len=32) :: filename
+    hsp = real(h,sp)
+    usp = real(0.5d0*(u(1:nlon,:) + u(2:nlon+1,:)), sp)
+    vsp = real(0.5d0*(v(:,1:nlat) + v(:,2:nlat+1)), sp)
+    write(filename,'("snapshot_",i4.4,".bin")') n
+    open(unit=20,file=filename,form='unformatted',access='stream',status='replace')
+    write(20) hsp, usp, vsp
+    close(20)
+  end subroutine write_snapshot
+
+  subroutine write_cost_log(mse,mass_res)
+    real(dp), intent(in) :: mse, mass_res
+    open(unit=40,file='cost.log',status='replace')
+    write(40,'(a,1x,e16.8)') 'MSE', mse
+    write(40,'(a,1x,e16.8)') 'MassResidual', mass_res
+    close(40)
+  end subroutine write_cost_log
+end module io_module

--- a/src/common/rk4_module.f90
+++ b/src/common/rk4_module.f90
@@ -1,0 +1,22 @@
+module rk4_module
+  use constants_module, only: dp
+  use variables_module, only: nlon, nlat, dt
+  use equations_module, only: rhs
+  implicit none
+contains
+  subroutine rk4_step(h,hn,u,v,lat)
+    real(dp), intent(in) :: h(nlon,nlat), u(nlon+1,nlat), v(nlon,nlat+1), lat(nlat)
+    real(dp), intent(out) :: hn(nlon,nlat)
+    real(dp) :: k1(nlon,nlat), k2(nlon,nlat)
+    real(dp) :: k3(nlon,nlat), k4(nlon,nlat)
+    real(dp) :: htmp(nlon,nlat)
+    call rhs(h, k1, u, v, lat)
+    htmp = h + 0.5d0*dt*k1
+    call rhs(htmp, k2, u, v, lat)
+    htmp = h + 0.5d0*dt*k2
+    call rhs(htmp, k3, u, v, lat)
+    htmp = h + dt*k3
+    call rhs(htmp, k4, u, v, lat)
+    hn = h + dt*(k1 + 2.d0*k2 + 2.d0*k3 + k4)/6.d0
+  end subroutine rk4_step
+end module rk4_module

--- a/src/common/variables_module.f90
+++ b/src/common/variables_module.f90
@@ -1,0 +1,44 @@
+module variables_module
+  use constants_module, only: dp, sp
+  implicit none
+  integer, parameter :: nlon=128, nlat=64
+  real(dp), parameter :: pi=3.14159265358979323846d0
+  real(dp), parameter :: radius=6371220.d0, g=9.80616d0
+  real(dp), parameter :: day=86400.d0
+  real(dp), parameter :: dlon=2.d0*pi/nlon, dlat=pi/nlat
+  real(dp), parameter :: h0=10000.d0, h1=2000.d0
+  real(dp), parameter :: omega=2.d0*pi/(12.d0*day)
+  real(dp), parameter :: dt=600.d0
+  integer, parameter :: nsteps=nint(12.d0*day/dt)
+  integer, parameter :: output_interval=48
+  real(dp), allocatable :: lon(:), lat(:)
+  real(dp), allocatable :: h(:,:), hn(:,:), ha(:,:)
+  real(dp), allocatable :: u(:,:), v(:,:)
+  real(sp), allocatable :: hsp(:,:), usp(:,:), vsp(:,:)
+contains
+  subroutine init_variables()
+    integer :: i, j
+    allocate(lon(nlon), lat(nlat))
+    allocate(h(nlon,nlat), hn(nlon,nlat), ha(nlon,nlat))
+    allocate(u(nlon+1,nlat), v(nlon,nlat+1))
+    allocate(hsp(nlon,nlat), usp(nlon,nlat), vsp(nlon,nlat))
+    do i=1,nlon
+       lon(i) = (i-0.5d0)*dlon
+    end do
+    do j=1,nlat
+       lat(j) = -pi/2.d0 + (j-0.5d0)*dlat
+    end do
+  end subroutine init_variables
+  subroutine finalize_variables()
+    if (allocated(lon)) deallocate(lon)
+    if (allocated(lat)) deallocate(lat)
+    if (allocated(h)) deallocate(h)
+    if (allocated(hn)) deallocate(hn)
+    if (allocated(ha)) deallocate(ha)
+    if (allocated(u)) deallocate(u)
+    if (allocated(v)) deallocate(v)
+    if (allocated(hsp)) deallocate(hsp)
+    if (allocated(usp)) deallocate(usp)
+    if (allocated(vsp)) deallocate(vsp)
+  end subroutine finalize_variables
+end module variables_module

--- a/src/cost_functions/cost_module.f90
+++ b/src/cost_functions/cost_module.f90
@@ -1,7 +1,6 @@
 module cost_module
+  use constants_module, only: dp
   implicit none
-  integer, parameter :: dp=kind(1.0d0)
-  integer, parameter :: sp=kind(1.0)
   real(dp), save :: reference_mass = -1.d0
 contains
 
@@ -24,6 +23,35 @@ contains
        residual = current_mass - reference_mass
     end if
   end function calc_mass_residual
+
+  !> Compute L1, L2, and Linf error norms
+  subroutine calc_error_norms(height_num, height_ana, lat, l1err, l2err, maxerr)
+    real(dp), intent(in) :: height_num(:,:), height_ana(:,:), lat(:)
+    real(dp), intent(out) :: l1err, l2err, maxerr
+    integer :: i, j, nlon, nlat
+    real(dp) :: err, w, wtsum
+
+    nlon = size(height_num, 1)
+    nlat = size(height_num, 2)
+    maxerr = 0.d0
+    l1err = 0.d0
+    l2err = 0.d0
+    wtsum = 0.d0
+
+    do j = 1, nlat
+       w = cos(lat(j))
+       wtsum = wtsum + w
+       do i = 1, nlon
+          err = height_num(i,j) - height_ana(i,j)
+          maxerr = max(maxerr, abs(err))
+          l1err = l1err + abs(err)*w
+          l2err = l2err + err*err*w
+       end do
+    end do
+
+    l1err = l1err/(nlon*wtsum)
+    l2err = sqrt(l2err/(nlon*wtsum))
+  end subroutine calc_error_norms
 
   !> Evaluate inner product of gradients with perturbation directions
   function evaluate_gradient(grad_ic, grad_param, dir_ic, dir_param) result(ip)

--- a/src/testcase1/Makefile
+++ b/src/testcase1/Makefile
@@ -1,12 +1,17 @@
 FC=gfortran
 FFLAGS=-O2
 
+COMMON=../common/constants_module.f90 ../common/variables_module.f90 \
+       ../common/equations_module.f90 ../common/rk4_module.f90 \
+       ../common/io_module.f90
+
 all: shallow_water_test1
 
-shallow_water_test1: shallow_water_test1.f90 ../cost_functions/cost_module.f90
-	$(FC) $(FFLAGS) -I../cost_functions -o $@ ../cost_functions/cost_module.f90 shallow_water_test1.f90
+shallow_water_test1: shallow_water_test1.f90 $(COMMON) ../cost_functions/cost_module.f90
+	$(FC) $(FFLAGS) -I../cost_functions -I../common -o $@ \
+	$(COMMON) ../cost_functions/cost_module.f90 shallow_water_test1.f90
 
 clean:
-	rm -f shallow_water_test1 error.dat snapshot_*.bin snapshot_*.png
+	rm -f shallow_water_test1 error.dat cost.log grid_params.txt snapshot_*.bin snapshot_*.png
 
 .PHONY: all clean

--- a/src/testcase1/shallow_water_test1.f90
+++ b/src/testcase1/shallow_water_test1.f90
@@ -1,258 +1,35 @@
 program shallow_water_test1
-  use cost_module, only: calc_mse, calc_mass_residual, dp, sp
+  use constants_module, only: dp
+  use cost_module, only: calc_mse, calc_mass_residual, calc_error_norms
+  use variables_module
+  use equations_module
+  use rk4_module
+  use io_module
   implicit none
-  ! Shallow water equation solver for cosine bell advection test case
-  integer, parameter :: nlon=128, nlat=64
-  real(dp), parameter :: pi=3.14159265358979323846d0
-  real(dp), parameter :: radius=6371220.d0, g=9.80616d0
-  real(dp), parameter :: day=86400.d0
-  real(dp), parameter :: dlon=2.d0*pi/nlon, dlat=pi/nlat
-  real(dp), parameter :: h0=10000.d0, h1=2000.d0
-  real(dp), parameter :: omega=2.d0*pi/(12.d0*day)
-  real(dp), parameter :: dt=600.d0
-  integer, parameter :: nsteps=nint(12.d0*day/dt)
-  integer, parameter :: output_interval=48
-  real(dp) :: lon(nlon), lat(nlat)
-  real(dp) :: h(nlon,nlat), hn(nlon,nlat)
-  real(dp) :: ha(nlon,nlat)
-  ! Arakawa C-grid staggering: u on zonal cell edges, v on meridional edges
-  real(dp) :: u(nlon+1,nlat), v(nlon,nlat+1)
-  real(dp) :: t, maxerr, l1err, l2err, alpha, wtsum, err, w, mse, mass_res
-  real(sp) :: hsp(nlon,nlat), usp(nlon,nlat), vsp(nlon,nlat)
-  integer :: i,j,n
-  character(len=32) :: carg, filename
-
-  ! Read solid body rotation angle alpha in degrees from command line
-  if (command_argument_count() >= 1) then
-     call get_command_argument(1,carg)
-     read(carg,*) alpha
-  else
-     alpha = 0.d0
-  end if
-  alpha = alpha*pi/180.d0
-
-  ! Write grid dimensions for use by plotting script
-  open(unit=30,file='grid_params.txt',status='replace')
-  write(30,*) nlon, nlat
-  close(30)
-
-  do i=1,nlon
-     lon(i) = (i-0.5d0)*dlon
-  end do
-  do j=1,nlat
-     lat(j) = -pi/2.d0 + (j-0.5d0)*dlat
-  end do
-
+  real(dp) :: t, maxerr, l1err, l2err, alpha, mse, mass_res
+  integer :: n
+  call init_variables()
+  call read_alpha(alpha)
+  call write_grid_params()
   call init_height(h, lon, lat)
-  ! initialize reference mass for conservation check
   mass_res = calc_mass_residual(h)
   call velocity_field(u, v, lon, lat, alpha)
-
-  open(unit=10,file='error.dat',status='replace')  ! t(days), L1, L2, Linf
+  call open_error_file()
   do n=0,nsteps
      t = n*dt
      call analytic_height(ha, lon, lat, t, alpha)
-     maxerr = 0.d0
-     l1err = 0.d0
-     l2err = 0.d0
-     wtsum = 0.d0
-     do j=1,nlat
-        w = cos(lat(j))
-        wtsum = wtsum + w
-        do i=1,nlon
-           err = h(i,j) - ha(i,j)
-           maxerr = max(maxerr, abs(err))
-           l1err = l1err + abs(err)*w
-           l2err = l2err + err*err*w
-        end do
-     end do
-     l1err = l1err/(nlon*wtsum)
-     l2err = sqrt(l2err/(nlon*wtsum))
-     write(10,'(f10.4,3(1x,e14.6))') t/day, l1err, l2err, maxerr
-
+     call calc_error_norms(h, ha, lat, l1err, l2err, maxerr)
+     call write_error(t, l1err, l2err, maxerr)
      if (mod(n,output_interval) == 0) then
-        hsp = real(h,sp)
-        ! Output cell-centered velocities averaged from C-grid edges
-        usp = real(0.5d0*(u(1:nlon,:) + u(2:nlon+1,:)), sp)
-        vsp = real(0.5d0*(v(:,1:nlat) + v(:,2:nlat+1)), sp)
-        write(filename,'("snapshot_",i4.4,".bin")') n
-        open(unit=20,file=filename,form='unformatted',access='stream',status='replace')
-        write(20) hsp, usp, vsp
-        close(20)
+        call write_snapshot(n)
      end if
-
      if (n == nsteps) exit
-     call step(h, hn, u, v, lat)
+     call rk4_step(h, hn, u, v, lat)
      h = hn
   end do
-  close(10)
-
-  ! Compute cost function diagnostics at final time
-  open(unit=40,file='cost.log',status='replace')
+  call close_error_file()
   mse = calc_mse(h, ha)
   mass_res = calc_mass_residual(h)
-  write(40,'(a,1x,e16.8)') 'MSE', mse
-  write(40,'(a,1x,e16.8)') 'MassResidual', mass_res
-  close(40)
-
-contains
-
-  subroutine init_height(h, lon, lat)
-    real(dp), intent(out) :: h(nlon,nlat)
-    real(dp), intent(in) :: lon(nlon), lat(nlat)
-    real(dp) :: lambda0, phi0, r0, dist
-    integer :: i,j
-    lambda0 = 3.d0*pi/2.d0
-    phi0 = 0.d0
-    r0 = radius/3.d0
-    do j=1,nlat
-       do i=1,nlon
-          h(i,j) = h0
-          call gc_distance(lon(i),lat(j),lambda0,phi0,dist)
-          if (dist < r0) then
-             h(i,j) = h0 + 0.5d0*h1*(1.d0+cos(pi*dist/r0))
-          end if
-       end do
-    end do
-  end subroutine init_height
-
-  subroutine velocity_field(u,v,lon,lat,alpha)
-    ! Compute velocity components on an Arakawa C-grid
-    real(dp), intent(out) :: u(nlon+1,nlat), v(nlon,nlat+1)
-    real(dp), intent(in) :: lon(nlon), lat(nlat), alpha
-    real(dp) :: u0, lon_edge
-    integer :: i,j
-    u0 = omega*radius
-    ! Zonal velocity on longitudinal cell edges
-    do j=1,nlat
-       do i=1,nlon+1
-          lon_edge = (i-1)*dlon
-          u(i,j) = u0*(cos(lat(j))*cos(alpha) + sin(lat(j))*cos(lon_edge)*sin(alpha))
-       end do
-    end do
-    ! Meridional velocity on latitudinal cell edges
-    do j=1,nlat+1
-       do i=1,nlon
-          v(i,j) = -u0*sin(lon(i))*sin(alpha)
-       end do
-    end do
-    v(:,1) = 0.d0
-    v(:,nlat+1) = 0.d0
-  end subroutine velocity_field
-
-  subroutine analytic_height(ha, lon, lat, t, alpha)
-    real(dp), intent(out) :: ha(nlon,nlat)
-    real(dp), intent(in) :: lon(nlon), lat(nlat), t, alpha
-    real(dp) :: lonr, latr, theta
-    integer :: i,j
-    theta = -omega*t
-    do j=1,nlat
-       do i=1,nlon
-          call rotate_point(lon(i),lat(j),alpha,theta,lonr,latr)
-          ha(i,j) = initial_at_point(lonr,latr)
-       end do
-    end do
-  end subroutine analytic_height
-
-  function initial_at_point(lon,lat) result(hp)
-    real(dp), intent(in) :: lon, lat
-    real(dp) :: hp, lambda0, phi0, r0, dist
-    lambda0 = 3.d0*pi/2.d0
-    phi0 = 0.d0
-    r0 = radius/3.d0
-    hp = h0
-    call gc_distance(lon,lat,lambda0,phi0,dist)
-    if (dist < r0) hp = h0 + 0.5d0*h1*(1.d0+cos(pi*dist/r0))
-  end function initial_at_point
-
-  subroutine gc_distance(lon1,lat1,lon2,lat2,dist)
-    real(dp), intent(in) :: lon1,lat1,lon2,lat2
-    real(dp), intent(out) :: dist
-    dist = radius*acos( sin(lat1)*sin(lat2) + cos(lat1)*cos(lat2)*cos(lon1-lon2) )
-  end subroutine gc_distance
-
-  subroutine rotate_point(lon,lat,alpha,theta,lonp,latp)
-    real(dp), intent(in) :: lon, lat, alpha, theta
-    real(dp), intent(out) :: lonp, latp
-    real(dp) :: x,y,z,xp,yp,zp
-    real(dp) :: n1,n2,n3,dot,c1,c2,c3,ct,st
-    x = cos(lat)*cos(lon)
-    y = cos(lat)*sin(lon)
-    z = sin(lat)
-    n1 = -sin(alpha)
-    n2 = 0.d0
-    n3 = cos(alpha)
-    ct = cos(theta)
-    st = sin(theta)
-    dot = n1*x + n2*y + n3*z
-    c1 = n2*z - n3*y
-    c2 = n3*x - n1*z
-    c3 = n1*y - n2*x
-    xp = x*ct + c1*st + n1*dot*(1.d0-ct)
-    yp = y*ct + c2*st + n2*dot*(1.d0-ct)
-    zp = z*ct + c3*st + n3*dot*(1.d0-ct)
-    lonp = atan2(yp,xp)
-    if (lonp < 0.d0) lonp = lonp + 2.d0*pi
-    latp = asin(zp)
-  end subroutine rotate_point
-
-  subroutine rhs(h,dhdt,u,v,lat)
-    real(dp), intent(in) :: h(nlon,nlat), u(nlon+1,nlat), v(nlon,nlat+1), lat(nlat)
-    real(dp), intent(out) :: dhdt(nlon,nlat)
-    ! First-order upwind fluxes on a C-grid
-    integer :: i,j,ip1,im1,jp1,jm1
-    real(dp) :: fe,fw,fn,fs,ue,uw,vn,vs
-
-    do j=1,nlat
-       jp1 = min(j+1,nlat)
-       jm1 = max(j-1,1)
-       do i=1,nlon
-          ip1 = mod(i,nlon)+1
-          im1 = mod(i-2+nlon,nlon)+1
-          ue = u(i+1,j)
-          uw = u(i,j)
-          if (ue > 0.d0) then
-             fe = ue*h(i,j)
-          else
-             fe = ue*h(ip1,j)
-          end if
-          if (uw > 0.d0) then
-             fw = uw*h(im1,j)
-          else
-             fw = uw*h(i,j)
-          end if
-          vn = v(i,j+1)
-          vs = v(i,j)
-          if (vn > 0.d0) then
-             fn = vn*h(i,j)
-          else
-             fn = vn*h(i,jp1)
-          end if
-          if (vs > 0.d0) then
-             fs = vs*h(i,jm1)
-          else
-             fs = vs*h(i,j)
-          end if
-          dhdt(i,j) = -((fe - fw)/(dlon*radius*cos(lat(j))) + (fn - fs)/(dlat*radius))
-       end do
-    end do
-  end subroutine rhs
-
-  subroutine step(h,hn,u,v,lat)
-    real(dp), intent(in) :: h(nlon,nlat), u(nlon+1,nlat), v(nlon,nlat+1), lat(nlat)
-    real(dp), intent(out) :: hn(nlon,nlat)
-    real(dp) :: k1(nlon,nlat), k2(nlon,nlat)
-    real(dp) :: k3(nlon,nlat), k4(nlon,nlat)
-    real(dp) :: htmp(nlon,nlat)
-
-    call rhs(h, k1, u, v, lat)
-    htmp = h + 0.5d0*dt*k1
-    call rhs(htmp, k2, u, v, lat)
-    htmp = h + 0.5d0*dt*k2
-    call rhs(htmp, k3, u, v, lat)
-    htmp = h + dt*k3
-    call rhs(htmp, k4, u, v, lat)
-    hn = h + dt*(k1 + 2.d0*k2 + 2.d0*k3 + k4)/6.d0
-  end subroutine step
-
+  call write_cost_log(mse, mass_res)
+  call finalize_variables()
 end program shallow_water_test1


### PR DESCRIPTION
## Summary
- Add `constants_module` providing shared `dp`/`sp` kind parameters
- Move error norm calculations into `cost_module` and expose `calc_error_norms`
- Rename modules for consistent `_module` naming and update build configuration

## Testing
- `cd src/testcase1 && make clean && make`
- `./shallow_water_test1 >/tmp/run.log && wc -l /tmp/run.log`


------
https://chatgpt.com/codex/tasks/task_b_688d453aee04832db398c1e3006467b7