### PR TITLE
Add runtime switch for snapshot output

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 # shallow_water_adjoint
 Shallow water equation model with adjoint model
+
+The test program `shallow_water_test1` accepts two optional command-line
+arguments:
+
+1. Rotation angle `alpha` in degrees.
+2. A flag to control snapshot output. Set this to `0` to disable writing
+   `snapshot_*.bin` files; any non-zero value enables snapshots (default).

--- a/src/common/io_module.f90
+++ b/src/common/io_module.f90
@@ -15,6 +15,19 @@ contains
     alpha = alpha*pi/180.d0
   end subroutine read_alpha
 
+  subroutine read_snapshot_flag(flag)
+    logical, intent(out) :: flag
+    character(len=32) :: carg
+    integer :: inum
+    if (command_argument_count() >= 2) then
+       call get_command_argument(2,carg)
+       read(carg,*) inum
+       flag = (inum /= 0)
+    else
+       flag = .true.
+    end if
+  end subroutine read_snapshot_flag
+
   subroutine write_grid_params()
     open(unit=30,file='grid_params.txt',status='replace')
     write(30,*) nlon, nlat

--- a/src/testcase1/shallow_water_test1.f90
+++ b/src/testcase1/shallow_water_test1.f90
@@ -8,8 +8,10 @@ program shallow_water_test1
   implicit none
   real(dp) :: t, maxerr, l1err, l2err, alpha, mse, mass_res
   integer :: n
+  logical :: snapshot_flag
   call init_variables()
   call read_alpha(alpha)
+  call read_snapshot_flag(snapshot_flag)
   call write_grid_params()
   call init_height(h, lon, lat)
   mass_res = calc_mass_residual(h)
@@ -20,9 +22,9 @@ program shallow_water_test1
      call analytic_height(ha, lon, lat, t, alpha)
      call calc_error_norms(h, ha, lat, l1err, l2err, maxerr)
      call write_error(t, l1err, l2err, maxerr)
-     if (mod(n,output_interval) == 0) then
-        call write_snapshot(n)
-     end if
+    if (snapshot_flag .and. mod(n,output_interval) == 0) then
+       call write_snapshot(n)
+    end if
      if (n == nsteps) exit
      call rk4_step(h, hn, u, v, lat)
      h = hn


### PR DESCRIPTION
## Summary
- allow runtime control of snapshot generation via new command-line flag
- update documentation for new snapshot flag

## Testing
- `make`
- `./shallow_water_test1 0 0`
- `./shallow_water_test1 0 1`


------
https://chatgpt.com/codex/tasks/task_b_688d4f113db0832d9d3d206976e819bf