### PR TITLE
Fix wind vector orientation in snapshot plots

### DIFF
--- a/src/testcase1/plot_snapshots.py
+++ b/src/testcase1/plot_snapshots.py
@@ -24,7 +24,10 @@ lon = np.arange(nlon) * dlon
 lat = -pi / 2.0 + (np.arange(nlat) + 0.5) * dlat
 lon_deg = np.degrees(lon)
 lat_deg = np.degrees(lat)
-lon2, lat2 = np.meshgrid(lon_deg, lat_deg, indexing='ij')
+# Use default 'xy' indexing so that the first dimension corresponds to
+# latitude and the second to longitude, matching the transposed data
+# arrays passed to ``quiver``.
+lon2, lat2 = np.meshgrid(lon_deg, lat_deg)
 
 npts = nlon * nlat
 for fname in sorted(glob.glob('snapshot_*.bin')):


### PR DESCRIPTION
## Summary
- ensure meshgrid uses xy indexing so quiver vectors align with data

## Testing
- `python -m py_compile src/testcase1/plot_snapshots.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_688d648de678832db6422a4fd70791b7