### PR TITLE
Add AD build support and example forward/reverse drivers

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,21 @@ arguments:
 1. Rotation angle `alpha` in degrees.
 2. A flag to control snapshot output. Set this to `0` to disable writing
    `snapshot_*.bin` files; any non-zero value enables snapshots (default).
+
+## Building and running
+
+Generate automatic differentiation modules and build executables:
+
+```bash
+cd build
+make ad
+make
+```
+
+This produces three binaries under `build`:
+
+- `shallow_water_test1` – original program
+- `shallow_water_forward` – forward mode example
+- `shallow_water_reverse` – reverse mode example
+
+Use `scripts/setup_fautodiff.sh` to ensure `fautodiff` is installed before building.

--- a/build/.gitignore
+++ b/build/.gitignore
@@ -1,0 +1,2 @@
+*
+!Makefile

--- a/build/Makefile
+++ b/build/Makefile
@@ -1,0 +1,37 @@
+.PHONY: all ad clean ensure_fautodiff
+.RECIPEPREFIX := >
+
+FC = gfortran
+FFLAGS ?= -O2 -ffree-line-length-none
+
+all: shallow_water_test1 shallow_water_forward shallow_water_reverse
+
+shallow_water_test1:
+>$(FC) $(FFLAGS) ../src/common/constants_module.f90 ../src/common/variables_module.f90 ../src/common/equations_module.f90 ../src/common/rk4_module.f90 ../src/common/io_module.f90 ../src/cost_functions/cost_module.f90 ../src/testcase1/shallow_water_test1.f90 -o $@
+
+shallow_water_forward: ad ../src/testcase1/shallow_water_forward.f90
+>$(FC) $(FFLAGS) -c fautodiff_stack.f90
+>$(FC) $(FFLAGS) -c ../src/common/constants_module.f90
+>$(FC) $(FFLAGS) -c ../src/cost_functions/cost_module.f90
+>$(FC) $(FFLAGS) -c constants_module_ad.f90
+>$(FC) $(FFLAGS) -c cost_module_ad.f90
+>$(FC) $(FFLAGS) -I. fautodiff_stack.o constants_module.o cost_module.o constants_module_ad.o cost_module_ad.o ../src/testcase1/shallow_water_forward.f90 -o $@
+
+shallow_water_reverse: ad ../src/testcase1/shallow_water_reverse.f90
+>$(FC) $(FFLAGS) -c fautodiff_stack.f90
+>$(FC) $(FFLAGS) -c ../src/common/constants_module.f90
+>$(FC) $(FFLAGS) -c ../src/cost_functions/cost_module.f90
+>$(FC) $(FFLAGS) -c constants_module_ad.f90
+>$(FC) $(FFLAGS) -c cost_module_ad.f90
+>$(FC) $(FFLAGS) -I. fautodiff_stack.o constants_module.o cost_module.o constants_module_ad.o cost_module_ad.o ../src/testcase1/shallow_water_reverse.f90 -o $@
+
+ad: ensure_fautodiff
+>python -m fortran_modules.gen_fautodiff_stack > fautodiff_stack.f90
+>fautodiff ../src/common/constants_module.f90 -M . -o constants_module_ad.f90
+>fautodiff ../src/cost_functions/cost_module.f90 -M . -I . -o cost_module_ad.f90
+
+ensure_fautodiff:
+>../scripts/setup_fautodiff.sh
+
+clean:
+>rm -f *.o *.mod shallow_water_test1 shallow_water_forward shallow_water_reverse *_ad.f90 *.fadmod fautodiff_stack.f90

--- a/scripts/setup_fautodiff.sh
+++ b/scripts/setup_fautodiff.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -e
+if ! command -v fautodiff >/dev/null 2>&1; then
+  echo "Installing fautodiff..."
+  pip install git+https://github.com/seiya/fautodiff >/tmp/fautodiff_install.log
+  tail -n 20 /tmp/fautodiff_install.log
+else
+  echo "fautodiff already installed."
+fi

--- a/src/testcase1/shallow_water_forward.f90
+++ b/src/testcase1/shallow_water_forward.f90
@@ -1,0 +1,15 @@
+program shallow_water_forward
+  use constants_module_ad, only: dp
+  use cost_module_ad, only: calc_mse_fwd_ad
+  implicit none
+  real(dp) :: a(2,2), a_ad(2,2)
+  real(dp) :: b(2,2), b_ad(2,2)
+  real(dp) :: mse, mse_ad
+  a = reshape([1.d0,2.d0,3.d0,4.d0],[2,2])
+  b = reshape([1.5d0,2.5d0,3.5d0,4.5d0],[2,2])
+  a_ad = 1.d0
+  b_ad = 0.d0
+  call calc_mse_fwd_ad(a, a_ad, b, b_ad, mse, mse_ad)
+  print *, 'mse =', mse
+  print *, 'mse_ad =', mse_ad
+end program shallow_water_forward

--- a/src/testcase1/shallow_water_reverse.f90
+++ b/src/testcase1/shallow_water_reverse.f90
@@ -1,0 +1,14 @@
+program shallow_water_reverse
+  use constants_module_ad, only: dp
+  use cost_module_ad, only: calc_mse_rev_ad
+  implicit none
+  real(dp) :: a(2,2), a_ad(2,2)
+  real(dp) :: b(2,2), b_ad(2,2)
+  real(dp) :: mse_ad
+  a = reshape([1.d0,2.d0,3.d0,4.d0],[2,2])
+  b = reshape([1.5d0,2.5d0,3.5d0,4.5d0],[2,2])
+  mse_ad = 1.d0
+  call calc_mse_rev_ad(a, a_ad, b, b_ad, mse_ad)
+  print *, 'a_ad =', a_ad
+  print *, 'b_ad =', b_ad
+end program shallow_water_reverse


### PR DESCRIPTION
## Summary
- add script to install `fautodiff`
- add build system for original and AD-generated programs
- provide forward and reverse example drivers
- document build steps in README

## Testing
- `make ad` *(fails: None)*
- `make` *(fails: Error: Inconsistent ranks for operator at (1) and (2))*

------
https://chatgpt.com/codex/tasks/task_b_688d6916b7dc832d99ee1f2d014d7b29