### PR TITLE
Use python3 for build and setup scripts

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -26,7 +26,7 @@ shallow_water_reverse: ad ../src/testcase1/shallow_water_reverse.f90
 >$(FC) $(FFLAGS) -I. fautodiff_stack.o constants_module.o cost_module.o constants_module_ad.o cost_module_ad.o ../src/testcase1/shallow_water_reverse.f90 -o $@
 
 ad: ensure_fautodiff
->python -m fortran_modules.gen_fautodiff_stack > fautodiff_stack.f90
+>python3 -m fortran_modules.gen_fautodiff_stack > fautodiff_stack.f90
 >fautodiff ../src/common/constants_module.f90 -M . -o constants_module_ad.f90
 >fautodiff ../src/cost_functions/cost_module.f90 -M . -I . -o cost_module_ad.f90
 

--- a/scripts/setup_fautodiff.sh
+++ b/scripts/setup_fautodiff.sh
@@ -2,7 +2,7 @@
 set -e
 if ! command -v fautodiff >/dev/null 2>&1; then
   echo "Installing fautodiff..."
-  pip install git+https://github.com/seiya/fautodiff >/tmp/fautodiff_install.log
+  python3 -m pip install git+https://github.com/seiya/fautodiff >/tmp/fautodiff_install.log
   tail -n 20 /tmp/fautodiff_install.log
 else
   echo "fautodiff already installed."


### PR DESCRIPTION
## Summary
- replace python with python3 in build Makefile
- ensure setup script installs with `python3 -m pip`

## Testing
- `make ad` *(fails: fautodiff: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_688d6d262588832db3f59e654c2ef729