### PR TITLE
Copy fautodiff modules before running

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -26,7 +26,7 @@ shallow_water_reverse: ad ../src/testcase1/shallow_water_reverse.f90
 >$(FC) $(FFLAGS) -I. fautodiff_stack.o constants_module.o cost_module.o constants_module_ad.o cost_module_ad.o ../src/testcase1/shallow_water_reverse.f90 -o $@
 
 ad: ensure_fautodiff
->python -m fortran_modules.gen_fautodiff_stack > fautodiff_stack.f90
+>../scripts/copy_fautodiff_modules.sh
 >fautodiff ../src/common/constants_module.f90 -M . -o constants_module_ad.f90
 >fautodiff ../src/cost_functions/cost_module.f90 -M . -I . -o cost_module_ad.f90
 

--- a/scripts/copy_fautodiff_modules.sh
+++ b/scripts/copy_fautodiff_modules.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Copy required Fortran modules from the installed fautodiff package
+# into the current working directory (build directory).
+
+src_dir=$(python - <<'PY'
+import fautodiff
+from pathlib import Path
+print((Path(fautodiff.__file__).resolve().parent.parent / 'fortran_modules'))
+PY
+)
+
+if [ ! -d "$src_dir" ] || ! ls "$src_dir"/*.f90 >/dev/null 2>&1; then
+  tmp_dir=$(mktemp -d)
+  git clone --depth 1 https://github.com/seiya/fautodiff "$tmp_dir" >/tmp/fautodiff_copy.log
+  tail -n 20 /tmp/fautodiff_copy.log
+  src_dir="$tmp_dir/fortran_modules"
+  cp "$src_dir"/*.f90 "$src_dir"/*.fadmod .
+  rm -rf "$tmp_dir"
+else
+  cp "$src_dir"/*.f90 "$src_dir"/*.fadmod .
+fi


### PR DESCRIPTION
## Summary
- copy Fortran module files from `fautodiff` into the build directory before running `fautodiff`
- remove redundant `gen_fautodiff_stack` step from the `ad` build target

## Testing
- `make ad`


------
https://chatgpt.com/codex/tasks/task_b_688d6f1f0724832d907fcaa3fd38fcc4