### PR TITLE
Improve fautodiff setup robustness

### DIFF
--- a/scripts/copy_fautodiff_modules.sh
+++ b/scripts/copy_fautodiff_modules.sh
@@ -5,19 +5,24 @@ set -euo pipefail
 # into the current working directory (build directory).
 
 src_dir=$(python3 - <<'PY'
-import fautodiff
 from pathlib import Path
-print((Path(fautodiff.__file__).resolve().parent.parent / 'fortran_modules'))
+try:
+    import fautodiff
+    print(Path(fautodiff.__file__).resolve().parent.parent / "fortran_modules")
+except ModuleNotFoundError:
+    pass
 PY
 )
 
-if [ ! -d "$src_dir" ] || ! ls "$src_dir"/*.f90 >/dev/null 2>&1; then
+# If the installed package is unavailable or does not contain the expected
+# Fortran sources, fall back to cloning the repository.
+if [ -n "$src_dir" ] && [ -d "$src_dir" ] && ls "$src_dir"/*.f90 >/dev/null 2>&1; then
+  cp "$src_dir"/*.f90 "$src_dir"/*.fadmod .
+else
   tmp_dir=$(mktemp -d)
   git clone --depth 1 https://github.com/seiya/fautodiff "$tmp_dir" >/tmp/fautodiff_copy.log
   tail -n 20 /tmp/fautodiff_copy.log
   src_dir="$tmp_dir/fortran_modules"
   cp "$src_dir"/*.f90 "$src_dir"/*.fadmod .
   rm -rf "$tmp_dir"
-else
-  cp "$src_dir"/*.f90 "$src_dir"/*.fadmod .
 fi

--- a/scripts/setup_fautodiff.sh
+++ b/scripts/setup_fautodiff.sh
@@ -2,8 +2,19 @@
 set -e
 if ! command -v fautodiff >/dev/null 2>&1; then
   echo "Installing fautodiff..."
-  python3 -m pip install git+https://github.com/seiya/fautodiff >/tmp/fautodiff_install.log
+  # Install fautodiff into the global Python environment so that the
+  # module and corresponding ``fautodiff`` executable are importable from
+  # subsequent scripts.  ``--break-system-packages`` is required on some
+  # systems (e.g. Debian/Ubuntu with PEP 668) to allow installation into
+  # the system site-packages when not using a virtual environment.
+  python3 -m pip install --break-system-packages \
+    git+https://github.com/seiya/fautodiff >/tmp/fautodiff_install.log
   tail -n 20 /tmp/fautodiff_install.log
+  # When using pyenv, newly installed executables are only available via
+  # shims after ``pyenv rehash``.  Do this silently if pyenv exists.
+  if command -v pyenv >/dev/null 2>&1; then
+    pyenv rehash >/dev/null 2>&1 || true
+  fi
 else
   echo "fautodiff already installed."
 fi


### PR DESCRIPTION
## Summary
- Install fautodiff into the global Python environment using `--break-system-packages` and run `pyenv rehash` so the executable is available
- Gracefully handle missing fautodiff module in `copy_fautodiff_modules.sh` by falling back to cloning the repository when needed

## Testing
- `cd build && make clean`
- `cd build && make` *(fails: Inconsistent ranks for operator at (1) and (2))*

------
https://chatgpt.com/codex/tasks/task_b_688d75bb3a10832dafc5f7aa39408612