### PR TITLE
Clone fautodiff instead of pip install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ src/testcase1/cost.log
 src/testcase1/*.mod
 src/testcase1/run.log
 src/testcase1/grid_params.txt
+scripts/fautodiff

--- a/README.md
+++ b/README.md
@@ -24,4 +24,4 @@ This produces three binaries under `build`:
 - `shallow_water_forward` – forward mode example
 - `shallow_water_reverse` – reverse mode example
 
-Use `scripts/setup_fautodiff.sh` to ensure `fautodiff` is installed before building.
+Use `scripts/setup_fautodiff.sh` to clone `fautodiff` before building.

--- a/build/Makefile
+++ b/build/Makefile
@@ -27,8 +27,8 @@ shallow_water_reverse: ad ../src/testcase1/shallow_water_reverse.f90
 
 ad: ensure_fautodiff
 >../scripts/copy_fautodiff_modules.sh
->fautodiff ../src/common/constants_module.f90 -M . -o constants_module_ad.f90
->fautodiff ../src/cost_functions/cost_module.f90 -M . -I . -o cost_module_ad.f90
+>../scripts/fautodiff/bin/fautodiff ../src/common/constants_module.f90 -M . -o constants_module_ad.f90
+>../scripts/fautodiff/bin/fautodiff ../src/cost_functions/cost_module.f90 -M . -I . -o cost_module_ad.f90
 
 ensure_fautodiff:
 >../scripts/setup_fautodiff.sh

--- a/scripts/copy_fautodiff_modules.sh
+++ b/scripts/copy_fautodiff_modules.sh
@@ -1,28 +1,16 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Copy required Fortran modules from the installed fautodiff package
+# Copy required Fortran modules from the fautodiff source tree
 # into the current working directory (build directory).
 
-src_dir=$(python3 - <<'PY'
-from pathlib import Path
-try:
-    import fautodiff
-    print(Path(fautodiff.__file__).resolve().parent.parent / "fortran_modules")
-except ModuleNotFoundError:
-    pass
-PY
-)
-
-# If the installed package is unavailable or does not contain the expected
-# Fortran sources, fall back to cloning the repository.
-if [ -n "$src_dir" ] && [ -d "$src_dir" ] && ls "$src_dir"/*.f90 >/dev/null 2>&1; then
-  cp "$src_dir"/*.f90 "$src_dir"/*.fadmod .
+FAUTODIFF_SRC="../scripts/fautodiff/fortran_modules"
+if [ -d "$FAUTODIFF_SRC" ]; then
+  cp "$FAUTODIFF_SRC"/*.f90 "$FAUTODIFF_SRC"/*.fadmod .
 else
   tmp_dir=$(mktemp -d)
   git clone --depth 1 https://github.com/seiya/fautodiff "$tmp_dir" >/tmp/fautodiff_copy.log
   tail -n 20 /tmp/fautodiff_copy.log
-  src_dir="$tmp_dir/fortran_modules"
-  cp "$src_dir"/*.f90 "$src_dir"/*.fadmod .
+  cp "$tmp_dir/fortran_modules"/*.f90 "$tmp_dir/fortran_modules"/*.fadmod .
   rm -rf "$tmp_dir"
 fi

--- a/scripts/setup_fautodiff.sh
+++ b/scripts/setup_fautodiff.sh
@@ -1,20 +1,11 @@
 #!/usr/bin/env bash
 set -e
-if ! command -v fautodiff >/dev/null 2>&1; then
-  echo "Installing fautodiff..."
-  # Install fautodiff into the global Python environment so that the
-  # module and corresponding ``fautodiff`` executable are importable from
-  # subsequent scripts.  ``--break-system-packages`` is required on some
-  # systems (e.g. Debian/Ubuntu with PEP 668) to allow installation into
-  # the system site-packages when not using a virtual environment.
-  python3 -m pip install --break-system-packages \
-    git+https://github.com/seiya/fautodiff >/tmp/fautodiff_install.log
-  tail -n 20 /tmp/fautodiff_install.log
-  # When using pyenv, newly installed executables are only available via
-  # shims after ``pyenv rehash``.  Do this silently if pyenv exists.
-  if command -v pyenv >/dev/null 2>&1; then
-    pyenv rehash >/dev/null 2>&1 || true
-  fi
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+FAUTODIFF_DIR="$SCRIPT_DIR/fautodiff"
+if [ ! -d "$FAUTODIFF_DIR" ]; then
+  echo "Cloning fautodiff..."
+  git clone --depth 1 https://github.com/seiya/fautodiff "$FAUTODIFF_DIR" >/tmp/fautodiff_clone.log
+  tail -n 20 /tmp/fautodiff_clone.log
 else
-  echo "fautodiff already installed."
+  echo "fautodiff already cloned."
 fi


### PR DESCRIPTION
## Summary
- clone fautodiff source instead of installing via pip
- copy Fortran modules from cloned source
- call local fautodiff binary from Makefile

## Testing
- `cd build && make ad`
- `cd build && make` *(fails: Inconsistent ranks for operator at (1) and (2))*

------
https://chatgpt.com/codex/tasks/task_b_688d77c9e2d4832d9a12923dcea6d9e4