### PR TITLE
Ensure fautodiff setup updates existing clone

### DIFF
--- a/scripts/setup_fautodiff.sh
+++ b/scripts/setup_fautodiff.sh
@@ -1,11 +1,16 @@
 #!/usr/bin/env bash
 set -e
+
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 FAUTODIFF_DIR="$SCRIPT_DIR/fautodiff"
-if [ ! -d "$FAUTODIFF_DIR" ]; then
+
+if [ ! -d "$FAUTODIFF_DIR/.git" ]; then
   echo "Cloning fautodiff..."
   git clone --depth 1 https://github.com/seiya/fautodiff "$FAUTODIFF_DIR" >/tmp/fautodiff_clone.log
   tail -n 20 /tmp/fautodiff_clone.log
 else
-  echo "fautodiff already cloned."
+  echo "Updating fautodiff..."
+  git -C "$FAUTODIFF_DIR" fetch --depth 1 origin main >/tmp/fautodiff_update.log
+  git -C "$FAUTODIFF_DIR" reset --hard origin/main >>/tmp/fautodiff_update.log
+  tail -n 20 /tmp/fautodiff_update.log
 fi


### PR DESCRIPTION
## Summary
- Remove Python helper and manage fautodiff checkout directly in `setup_fautodiff.sh`
- Update script to fetch and reset to `origin/main` when the repository already exists

## Testing
- `scripts/setup_fautodiff.sh`
- `scripts/setup_fautodiff.sh`
- `make -C build ensure_fautodiff`


------
https://chatgpt.com/codex/tasks/task_b_688dc74434d8832db8465ca339422432