### PR TITLE
Avoid redundant fautodiff stack rebuilds

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,10 @@ arguments:
 
 ## Building and running
 
-Generate automatic differentiation modules and build executables:
+Build executables (required fautodiff modules are fetched automatically):
 
 ```bash
 cd build
-make ad
 make
 ```
 
@@ -24,4 +23,4 @@ This produces three binaries under `build`:
 - `shallow_water_forward` – forward mode example
 - `shallow_water_reverse` – reverse mode example
 
-Use `scripts/setup_fautodiff.sh` to clone `fautodiff` before building.
+The build step will clone and copy `fautodiff` modules on demand.

--- a/build/Makefile
+++ b/build/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all ad clean ensure_fautodiff
+.PHONY: all ad clean
 .RECIPEPREFIX := >
 
 FC = gfortran
@@ -15,6 +15,7 @@ COMMON_OBJS = constants_module.o \
 COMMON_AD_OBJS = $(patsubst %.o,%_ad.o,$(COMMON_OBJS))
 
 FAUTODIFF_OBJS = fautodiff_stack.o
+FAUTODIFF_SRC  = fautodiff_stack.f90
 
 VPATH = ../src/common
 
@@ -29,17 +30,20 @@ shallow_water_test1_forward.out: ../src/testcase1/shallow_water_test1_forward.f9
 shallow_water_test1_reverse.out: ../src/testcase1/shallow_water_test1_reverse.f90 $(COMMON_OBJS) $(COMMON_AD_OBJS) $(FAUTODIFF_OBJS)
 >$(FC) $(FFLAGS) -I. -o $@ $^
 
+%_ad.o: %_ad.f90 $(FAUTODIFF_OBJS)
+>$(FC) $(FFLAGS) -c $< -o $@
+
 %.o: %.f90
 >$(FC) $(FFLAGS) -c $< -o $@
 
-%_ad.f90: %.f90 ad $(FAUTODIFF_OBJS)
+%_ad.f90: %.f90 $(FAUTODIFF_SRC)
 >../scripts/fautodiff/bin/fautodiff $< -I . -M . -o $@
 
-ad: ensure_fautodiff
->../scripts/copy_fautodiff_modules.sh
+ad: $(FAUTODIFF_SRC)
 
-ensure_fautodiff:
+$(FAUTODIFF_SRC):
 >../scripts/setup_fautodiff.sh
+>../scripts/copy_fautodiff_modules.sh
 
 clean:
 >rm -f *.o *.mod *.out *_ad.f90 *.fadmod fautodiff_stack.f90


### PR DESCRIPTION
## Summary
- ensure fautodiff modules are copied once and built before generating AD sources
- document that `make` now fetches fautodiff automatically

## Testing
- `make clean`
- `make`
- `make`


------
https://chatgpt.com/codex/tasks/task_b_688ed0ed2ef4832d8d6f494dd4efd87a