### PR TITLE
Copy fautodiff modules only when newer

### DIFF
--- a/scripts/copy_fautodiff_modules.sh
+++ b/scripts/copy_fautodiff_modules.sh
@@ -6,11 +6,11 @@ set -euo pipefail
 
 FAUTODIFF_SRC="../scripts/fautodiff/fortran_modules"
 if [ -d "$FAUTODIFF_SRC" ]; then
-  cp "$FAUTODIFF_SRC"/*.f90 "$FAUTODIFF_SRC"/*.fadmod .
+  cp -u "$FAUTODIFF_SRC"/*.f90 "$FAUTODIFF_SRC"/*.fadmod .
 else
   tmp_dir=$(mktemp -d)
   git clone --depth 1 https://github.com/seiya/fautodiff "$tmp_dir" >/tmp/fautodiff_copy.log
   tail -n 20 /tmp/fautodiff_copy.log
-  cp "$tmp_dir/fortran_modules"/*.f90 "$tmp_dir/fortran_modules"/*.fadmod .
+  cp -u "$tmp_dir/fortran_modules"/*.f90 "$tmp_dir/fortran_modules"/*.fadmod .
   rm -rf "$tmp_dir"
 fi


### PR DESCRIPTION
## Summary
- copy fautodiff Fortran modules only when source files are newer than the build directory's copy, avoiding needless recompilation

## Testing
- `../scripts/copy_fautodiff_modules.sh`
- `make` *(fails: Symbol `ha_ad` at (1) has no IMPLICIT type)*

------
https://chatgpt.com/codex/tasks/task_b_688f5310fc9c832d931ae79bb77c5f26