### PR TITLE
Add Taylor test for forward and reverse AD

### DIFF
--- a/scripts/plot_taylor_test1.py
+++ b/scripts/plot_taylor_test1.py
@@ -1,0 +1,21 @@
+import numpy as np
+import matplotlib.pyplot as plt
+from pathlib import Path
+
+def main():
+    build_dir = Path(__file__).resolve().parents[1] / 'build'
+    data = np.load(build_dir / 'taylor_test1_results.npz')
+    eps = data['eps']
+    fwd = data['fwd']
+    rev = data['rev']
+
+    plt.loglog(eps, fwd, 'o-', label='forward AD')
+    plt.loglog(eps, rev, 's-', label='reverse AD')
+    plt.xlabel('epsilon')
+    plt.ylabel('error')
+    plt.legend()
+    plt.grid(True, which='both')
+    plt.savefig(build_dir / 'taylor_test1_convergence.png')
+
+if __name__ == '__main__':
+    main()

--- a/src/common/io_module.f90
+++ b/src/common/io_module.f90
@@ -31,6 +31,16 @@ contains
   end subroutine read_snapshot_flag
 
   !$FAD SKIP
+  subroutine read_field(field, filename)
+    !! Read a two-dimensional field from a binary file.
+    real(dp), intent(out) :: field(nlon,nlat)
+    character(len=*), intent(in) :: filename
+    open(unit=50,file=filename,form='unformatted',access='stream',status='old')
+    read(50) field
+    close(50)
+  end subroutine read_field
+
+  !$FAD SKIP
   subroutine write_grid_params()
     open(unit=30,file='grid_params.txt',status='replace')
     write(30,*) nlon, nlat
@@ -72,8 +82,8 @@ contains
   subroutine write_cost_log(mse,mass_res)
     real(dp), intent(in) :: mse, mass_res
     open(unit=40,file='cost.log',status='replace')
-    write(40,'(a,1x,e16.8)') 'MSE', mse
-    write(40,'(a,1x,e16.8)') 'MassResidual', mass_res
+    write(40,'(a,1x,e25.16)') 'MSE', mse
+    write(40,'(a,1x,e25.16)') 'MassResidual', mass_res
     close(40)
   end subroutine write_cost_log
 end module io_module

--- a/src/testcase1/shallow_water_test1.f90
+++ b/src/testcase1/shallow_water_test1.f90
@@ -10,12 +10,18 @@ program shallow_water_test1
   real(dp) :: t, maxerr, l1err, l2err, alpha, mse, mass_res
   integer :: n
   logical :: snapshot_flag
+  character(len=256) :: carg
 
   call init_variables()
   call read_alpha(alpha)
   call read_snapshot_flag(snapshot_flag)
   call write_grid_params()
-  call init_height(h, lon, lat)
+  if (command_argument_count() >= 3) then
+     call get_command_argument(3, carg)
+     call read_field(h, trim(carg))
+  else
+     call init_height(h, lon, lat)
+  end if
   mass_res = calc_mass_residual(h)
   call velocity_field(u, v, lon, lat, alpha)
   call open_error_file()

--- a/tests/taylor_test1.py
+++ b/tests/taylor_test1.py
@@ -1,0 +1,69 @@
+import numpy as np
+import subprocess
+from pathlib import Path
+
+def save_field(path, arr):
+    path = Path(path)
+    arr.ravel(order='F').astype(np.float64).tofile(path)
+
+def read_cost(path):
+    path = Path(path)
+    with path.open() as f:
+        for line in f:
+            if line.startswith('MSE'):
+                return float(line.split()[1])
+    raise RuntimeError('MSE not found')
+
+def main():
+    build_dir = Path(__file__).resolve().parents[1] / 'build'
+    exe_base = build_dir / 'shallow_water_test1.out'
+    exe_fwd = build_dir / 'shallow_water_test1_forward.out'
+    exe_rev = build_dir / 'shallow_water_test1_reverse.out'
+
+    nlon, nlat = 128, 64
+    rng = np.random.default_rng(0)
+    x = rng.standard_normal((nlon, nlat))
+    d = rng.standard_normal((nlon, nlat))
+
+    x_file = build_dir / 'x.bin'
+    d_file = build_dir / 'd.bin'
+    save_field(x_file, x)
+    save_field(d_file, d)
+
+    subprocess.run([str(exe_base), '0', '0', str(x_file)], check=True, cwd=build_dir)
+    F0 = read_cost(build_dir / 'cost.log')
+
+    eps_list = np.logspace(-1, -5, num=5)
+    diffs = []
+    for i, eps in enumerate(eps_list):
+        x_eps = x + eps * d
+        x_eps_file = build_dir / f'x_eps_{i}.bin'
+        save_field(x_eps_file, x_eps)
+        subprocess.run([str(exe_base), '0', '0', str(x_eps_file)], check=True, cwd=build_dir)
+        Fe = read_cost(build_dir / 'cost.log')
+        diffs.append((Fe - F0) / eps)
+    diffs = np.array(diffs)
+
+    res = subprocess.run([str(exe_fwd), '0', '0', str(x_file), str(d_file)],
+                         check=True, cwd=build_dir, capture_output=True, text=True)
+    mse_ad = float(res.stdout.strip().split()[0])
+
+    res = subprocess.run([str(exe_rev), '0', '0', str(x_file), str(d_file)],
+                         check=True, cwd=build_dir, capture_output=True, text=True)
+    lines = res.stdout.strip().splitlines()
+    grad_dot_d = float(lines[-1].split()[0])
+
+    fwd_err = np.abs(mse_ad - diffs)
+    rev_err = np.abs(grad_dot_d - diffs)
+
+    for eps, diff, fe, re in zip(eps_list, diffs, fwd_err, rev_err):
+        print(f"eps={eps:.1e} diff={diff:.6e} fwd_err={fe:.6e} rev_err={re:.6e}")
+
+    np.savez(build_dir / 'taylor_test1_results.npz', eps=eps_list, diff=diffs,
+             fwd=fwd_err, rev=rev_err)
+
+    assert fwd_err[2] < fwd_err[0]
+    assert rev_err[2] < rev_err[0]
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- allow shallow water programs to read initial conditions and perturbations from binary files
- add Taylor test comparing finite differences with forward and reverse AD gradients
- include a helper script to plot convergence of the Taylor test
- fix indentation in reverse AD driver

## Testing
- `make -C build`
- `python tests/taylor_test1.py`
- `python scripts/plot_taylor_test1.py`


------
https://chatgpt.com/codex/tasks/task_b_68908cd820c4832d97f6ad796bb68bd6