### PR TITLE
Make snapshot interval configurable at runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ The test program `shallow_water_test1` accepts two optional command-line
 arguments:
 
 1. Rotation angle `alpha` in degrees.
-2. A flag to control snapshot output. Set this to `0` to disable writing
-   `snapshot_*.bin` files; any non-zero value enables snapshots (default).
+2. Snapshot output interval. The default is 48; specifying `0` outputs only
+   the final-time snapshot, and `-1` disables snapshot output entirely.
 
 ## Building and running
 

--- a/src/common/io_module.f90
+++ b/src/common/io_module.f90
@@ -17,18 +17,14 @@ contains
   end subroutine read_alpha
 
   !$FAD SKIP
-  subroutine read_snapshot_flag(flag)
-    logical, intent(out) :: flag
+  subroutine read_output_interval(interval)
+    integer, intent(inout) :: interval
     character(len=32) :: carg
-    integer :: inum
     if (command_argument_count() >= 2) then
        call get_command_argument(2,carg)
-       read(carg,*) inum
-       flag = (inum /= 0)
-    else
-       flag = .true.
+       read(carg,*) interval
     end if
-  end subroutine read_snapshot_flag
+  end subroutine read_output_interval
 
   !$FAD SKIP
   subroutine read_field(field, filename)

--- a/src/common/variables_module.f90
+++ b/src/common/variables_module.f90
@@ -10,7 +10,7 @@ module variables_module
   real(dp), parameter :: omega=2.d0*pi/(12.d0*day)
   real(dp), parameter :: dt=600.d0
   integer, parameter :: nsteps=nint(12.d0*day/dt)
-  integer, parameter :: output_interval=48
+  integer :: output_interval=48
   real(dp), allocatable :: lon(:), lat(:)
   real(dp), allocatable :: h(:,:), hn(:,:), ha(:,:)
   real(dp), allocatable :: u(:,:), v(:,:)

--- a/src/testcase1/shallow_water_test1.f90
+++ b/src/testcase1/shallow_water_test1.f90
@@ -9,12 +9,11 @@ program shallow_water_test1
 
   real(dp) :: t, maxerr, l1err, l2err, alpha, mse, mass_res
   integer :: n
-  logical :: snapshot_flag
   character(len=256) :: carg
 
   call init_variables()
   call read_alpha(alpha)
-  call read_snapshot_flag(snapshot_flag)
+  call read_output_interval(output_interval)
   call write_grid_params()
   if (command_argument_count() >= 3) then
      call get_command_argument(3, carg)
@@ -30,8 +29,12 @@ program shallow_water_test1
      call analytic_height(ha, lon, lat, t, alpha)
      call calc_error_norms(h, ha, lat, l1err, l2err, maxerr)
      call write_error(t, l1err, l2err, maxerr)
-     if (snapshot_flag .and. mod(n,output_interval) == 0) then
-        call write_snapshot(n, h, u, v)
+     if (output_interval /= -1) then
+        if (output_interval == 0) then
+           if (n == nsteps) call write_snapshot(n, h, u, v)
+        else if (mod(n, output_interval) == 0) then
+           call write_snapshot(n, h, u, v)
+        end if
      end if
      if (n == nsteps) exit
      call rk4_step(h, hn, u, v, lat)

--- a/src/testcase1/shallow_water_test1_forward.f90
+++ b/src/testcase1/shallow_water_test1_forward.f90
@@ -13,12 +13,11 @@ program shallow_water_test1_forward
   real(dp) :: t, maxerr, l1err, l2err, alpha, mse, mass_res
   real(dp) :: t_ad, maxerr_ad, l1err_ad, l2err_ad, mse_ad, mass_res_ad
   integer :: n
-  logical :: snapshot_flag
   character(len=256) :: carg
 
   call init_variables()
   call read_alpha(alpha)
-  call read_snapshot_flag(snapshot_flag)
+  call read_output_interval(output_interval)
   call write_grid_params()
   call init_variables_fwd_ad()
   ha = 0.0_dp
@@ -39,8 +38,12 @@ program shallow_water_test1_forward
   call velocity_field_fwd_ad(u, u_ad, v, v_ad, lon, lat, alpha)
   do n = 0, nsteps
      t = n*dt
-     if (snapshot_flag .and. mod(n,output_interval) == 0) then
-        call write_snapshot(n, h_ad, u, v)
+     if (output_interval /= -1) then
+        if (output_interval == 0) then
+           if (n == nsteps) call write_snapshot(n, h_ad, u, v)
+        else if (mod(n, output_interval) == 0) then
+           call write_snapshot(n, h_ad, u, v)
+        end if
      end if
      if (n == nsteps) exit
      call rk4_step_fwd_ad(h, h_ad, hn, hn_ad, u, u_ad, v, v_ad, lat)

--- a/src/testcase1/shallow_water_test1_reverse.f90
+++ b/src/testcase1/shallow_water_test1_reverse.f90
@@ -17,13 +17,12 @@ program shallow_water_test1_reverse
   real(dp) :: maxerr_ad, l1err_ad, l2err_ad, mse_ad, mass_res_ad
   real(dp) :: grad_dot_d
   integer :: n
-  logical :: snapshot_flag
   character(len=256) :: carg
   real(dp), allocatable :: d(:,:)
 
   call init_variables()
   call read_alpha(alpha)
-  call read_snapshot_flag(snapshot_flag)
+  call read_output_interval(output_interval)
   call write_grid_params()
   if (command_argument_count() >= 3) then
      call get_command_argument(3, carg)
@@ -66,8 +65,12 @@ program shallow_water_test1_reverse
         h_ad = 0.0_dp
         call rk4_step_rev_ad(h, h_ad, hn_ad, u, u_ad, v, v_ad, lat)
      end if
-     if (snapshot_flag .and. mod(n,output_interval) == 0) then
-        call write_snapshot(n, h_ad, u, v)
+     if (output_interval /= -1) then
+        if (output_interval == 0) then
+           if (n == 0) call write_snapshot(n, h_ad, u, v)
+        else if (mod(n, output_interval) == 0) then
+           call write_snapshot(n, h_ad, u, v)
+        end if
      end if
   end do
   !call velocity_field_rev_ad(u, u_ad, v, v_ad, lon, lat, alpha)

--- a/tests/adjoint_test1.py
+++ b/tests/adjoint_test1.py
@@ -28,13 +28,13 @@ def main():
     save_field(u_file, u)
 
     res = subprocess.run(
-        [str(exe_fwd), '0', '0', str(x_file), str(u_file)],
+        [str(exe_fwd), '0', '-1', str(x_file), str(u_file)],
         check=True, cwd=build_dir, capture_output=True, text=True
     )
     Ju = float(res.stdout.strip().split()[0])
 
     subprocess.run(
-        [str(exe_rev), '0', '1', str(x_file)],
+        [str(exe_rev), '0', '0', str(x_file)],
         check=True, cwd=build_dir, capture_output=True, text=True
     )
     g = read_snapshot(build_dir / 'snapshot_0000.bin', nlon, nlat)


### PR DESCRIPTION
## Summary
- allow specifying snapshot output interval as a single command-line argument
- emit only the final-time snapshot when the interval is 0, and disable snapshots with -1
- document the revised snapshot interval argument and update the adjoint test

## Testing
- `python tests/adjoint_test1.py`
- `pytest scripts/fautodiff/tests/test_fortran_adcode.py::TestFortranADCode::test_mpi_example -q` *(fails: mpifort: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_6891549f419c832db7826323d8d8f7cc