### PR TITLE
Add geostrophic steady-state test case with autodiff checks

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -19,7 +19,8 @@ FAUTODIFF_SRC  = fautodiff_stack.f90
 
 VPATH = ../src/common
 
-all: shallow_water_test1.out shallow_water_test1_forward.out shallow_water_test1_reverse.out
+all: shallow_water_test1.out shallow_water_test1_forward.out shallow_water_test1_reverse.out \
+     shallow_water_test2.out shallow_water_test2_forward.out shallow_water_test2_reverse.out
 
 shallow_water_test1.out: ../src/testcase1/shallow_water_test1.f90 $(COMMON_OBJS)
 >$(FC) $(FFLAGS) -o $@ $^
@@ -28,6 +29,15 @@ shallow_water_test1_forward.out: ../src/testcase1/shallow_water_test1_forward.f9
 >$(FC) $(FFLAGS) -I. -o $@ $^
 
 shallow_water_test1_reverse.out: ../src/testcase1/shallow_water_test1_reverse.f90 $(COMMON_OBJS) $(COMMON_AD_OBJS) $(FAUTODIFF_OBJS)
+>$(FC) $(FFLAGS) -I. -o $@ $^
+
+shallow_water_test2.out: ../src/testcase2/shallow_water_test2.f90 $(COMMON_OBJS)
+>$(FC) $(FFLAGS) -o $@ $^
+
+shallow_water_test2_forward.out: ../src/testcase2/shallow_water_test2_forward.f90 $(COMMON_OBJS) $(COMMON_AD_OBJS) $(FAUTODIFF_OBJS)
+>$(FC) $(FFLAGS) -I. -o $@ $^
+
+shallow_water_test2_reverse.out: ../src/testcase2/shallow_water_test2_reverse.f90 $(COMMON_OBJS) $(COMMON_AD_OBJS) $(FAUTODIFF_OBJS)
 >$(FC) $(FFLAGS) -I. -o $@ $^
 
 %_ad.o: %_ad.f90 $(FAUTODIFF_OBJS)

--- a/src/testcase2/shallow_water_test2.f90
+++ b/src/testcase2/shallow_water_test2.f90
@@ -1,0 +1,81 @@
+program shallow_water_test2
+  use constants_module, only: dp
+  use cost_module, only: calc_mse, calc_mass_residual, calc_error_norms
+  use variables_module
+  use rk4_module
+  use io_module
+  implicit none
+
+  real(dp) :: t, maxerr, l1err, l2err, mse, mass_res
+  integer :: n
+  character(len=256) :: carg
+
+  call init_variables()
+  call read_output_interval(output_interval)
+  call write_grid_params()
+
+  if (command_argument_count() >= 3) then
+     call get_command_argument(3, carg)
+     call read_field(h, trim(carg))
+     ha = h
+  else
+     call init_geostrophic_height(h, lon, lat)
+     ha = h
+  end if
+
+  call geostrophic_velocity(u, v, lat)
+  mass_res = calc_mass_residual(h)
+  call open_error_file()
+  do n = 0, nsteps
+     t = n*dt
+     call calc_error_norms(h, ha, lat, l1err, l2err, maxerr)
+     call write_error(t, l1err, l2err, maxerr)
+     if (output_interval /= -1) then
+        if (output_interval == 0) then
+           if (n == nsteps) call write_snapshot(n, h, u, v)
+        else if (mod(n, output_interval) == 0) then
+           call write_snapshot(n, h, u, v)
+        end if
+     end if
+     if (n == nsteps) exit
+     call rk4_step(h, hn, u, v, lat)
+     h = hn
+  end do
+  call close_error_file()
+  mse = calc_mse(h, ha)
+  mass_res = calc_mass_residual(h)
+  call write_cost_log(mse, mass_res)
+  call finalize_variables()
+
+contains
+
+  !$FAD CONSTANT_VARS: lon, lat
+  subroutine init_geostrophic_height(h, lon, lat)
+    real(dp), intent(out) :: h(nlon,nlat)
+    real(dp), intent(in) :: lon(nlon), lat(nlat)
+    integer :: i, j
+    real(dp) :: coeff
+    real(dp), parameter :: u0 = 20.d0
+    coeff = (radius*u0*omega/g + 0.5d0*u0*u0/g)
+    do j = 1, nlat
+       do i = 1, nlon
+          h(i,j) = h0 - coeff * cos(lat(j))**2
+       end do
+    end do
+  end subroutine init_geostrophic_height
+
+  !$FAD CONSTANT_VARS: lat
+  subroutine geostrophic_velocity(u, v, lat)
+    real(dp), intent(out) :: u(nlon+1,nlat), v(nlon,nlat+1)
+    real(dp), intent(in) :: lat(nlat)
+    integer :: i, j
+    real(dp), parameter :: u0 = 20.d0
+    do j = 1, nlat
+       do i = 1, nlon+1
+          u(i,j) = u0 * cos(lat(j))
+       end do
+    end do
+    v = 0.d0
+  end subroutine geostrophic_velocity
+
+end program shallow_water_test2

--- a/src/testcase2/shallow_water_test2_forward.f90
+++ b/src/testcase2/shallow_water_test2_forward.f90
@@ -1,0 +1,90 @@
+program shallow_water_test2_forward
+  use constants_module, only: dp
+  use cost_module, only: calc_mse, calc_mass_residual
+  use cost_module_ad, only: calc_mse_fwd_ad, calc_mass_residual_fwd_ad
+  use variables_module
+  use variables_module_ad
+  use equations_module
+  use equations_module_ad
+  use rk4_module
+  use rk4_module_ad
+  use io_module
+  implicit none
+
+  real(dp) :: t, mse, mass_res
+  real(dp) :: t_ad, mse_ad, mass_res_ad
+  integer :: n
+  character(len=256) :: carg
+
+  call init_variables()
+  call read_output_interval(output_interval)
+  call write_grid_params()
+  call init_variables_fwd_ad()
+  ha = 0.0_dp
+  if (command_argument_count() >= 3) then
+     call get_command_argument(3, carg)
+     call read_field(h, trim(carg))
+     ha = h
+  else
+     call init_geostrophic_height_fwd_ad(h, h_ad, lon, lat)
+     ha = h
+  end if
+  if (command_argument_count() >= 4) then
+     call get_command_argument(4, carg)
+     call read_field(h_ad, trim(carg))
+  else
+     h_ad = 0.0_dp
+  end if
+  call geostrophic_velocity_fwd_ad(u, u_ad, v, v_ad, lat)
+  do n = 0, nsteps
+     if (n == nsteps) exit
+     call rk4_step_fwd_ad(h, h_ad, hn, hn_ad, u, u_ad, v, v_ad, lat)
+     h = hn
+     h_ad = hn_ad
+  end do
+  mse = calc_mse(h, ha)
+  mass_res = calc_mass_residual(h)
+  call calc_mse_fwd_ad(h, h_ad, ha, mse, mse_ad)
+  call calc_mass_residual_fwd_ad(h, h_ad, mass_res, mass_res_ad)
+  call write_cost_log(mse, mass_res)
+  print *, mse_ad, mass_res_ad
+  call finalize_variables_fwd_ad()
+
+contains
+
+  subroutine init_geostrophic_height_fwd_ad(h, h_ad, lon, lat)
+    real(dp), intent(out) :: h(nlon,nlat)
+    real(dp), intent(out) :: h_ad(nlon,nlat)
+    real(dp), intent(in)  :: lon(nlon)
+    real(dp), intent(in)  :: lat(nlat)
+    real(dp), parameter :: u0 = 20.d0
+    real(dp) :: coeff
+    integer :: i, j
+    coeff = radius*u0*omega/g + 0.5d0*u0*u0/g
+    do j = 1, nlat
+       do i = 1, nlon
+          h_ad(i,j) = 0.0_dp
+          h(i,j) = h0 - coeff * cos(lat(j))**2
+       end do
+    end do
+  end subroutine init_geostrophic_height_fwd_ad
+
+  subroutine geostrophic_velocity_fwd_ad(u, u_ad, v, v_ad, lat)
+    real(dp), intent(out) :: u(nlon+1,nlat)
+    real(dp), intent(out) :: u_ad(nlon+1,nlat)
+    real(dp), intent(out) :: v(nlon,nlat+1)
+    real(dp), intent(out) :: v_ad(nlon,nlat+1)
+    real(dp), intent(in)  :: lat(nlat)
+    real(dp), parameter :: u0 = 20.d0
+    integer :: i, j
+    do j = 1, nlat
+       do i = 1, nlon+1
+          u_ad(i,j) = 0.0_dp
+          u(i,j) = u0 * cos(lat(j))
+       end do
+    end do
+    v_ad = 0.0_dp
+    v = 0.d0
+  end subroutine geostrophic_velocity_fwd_ad
+
+end program shallow_water_test2_forward

--- a/src/testcase2/shallow_water_test2_reverse.f90
+++ b/src/testcase2/shallow_water_test2_reverse.f90
@@ -1,0 +1,107 @@
+program shallow_water_test2_reverse
+  use constants_module, only: dp
+  use cost_module, only: calc_mse, calc_mass_residual
+  use cost_module_ad, only: calc_mse_rev_ad, calc_mass_residual_rev_ad
+  use variables_module
+  use variables_module_ad
+  use equations_module
+  use equations_module_ad
+  use rk4_module
+  use rk4_module_ad
+  use io_module
+  use io_module_ad
+  use fautodiff_stack
+  implicit none
+
+  real(dp) :: t, mse, mass_res
+  real(dp) :: mse_ad, mass_res_ad, grad_dot_d
+  integer :: n
+  character(len=256) :: carg
+  real(dp), allocatable :: d(:,:)
+
+  call init_variables()
+  call read_output_interval(output_interval)
+  call write_grid_params()
+  if (command_argument_count() >= 3) then
+     call get_command_argument(3, carg)
+     call read_field(h, trim(carg))
+  else
+     call init_geostrophic_height(h, lon, lat)
+  end if
+  ha = h
+  allocate(d(nlon,nlat))
+  if (command_argument_count() >= 4) then
+     call get_command_argument(4, carg)
+     call read_field(d, trim(carg))
+  else
+     d = 0.0_dp
+  end if
+  call geostrophic_velocity(u, v, lat)
+  do n = 0, nsteps
+     call fautodiff_stack_push_r(h)
+     if (n == nsteps) exit
+     call rk4_step(h, hn, u, v, lat)
+     h = hn
+  end do
+  mse = calc_mse(h, ha)
+  mass_res = calc_mass_residual(h)
+
+  call finalize_variables_rev_ad()
+
+  mse_ad = 1.0_dp
+  mass_res_ad = 0.0_dp
+  h_ad = 0.0_dp
+
+  call calc_mass_residual_rev_ad(h, h_ad, mass_res_ad)
+  call calc_mse_rev_ad(h, h_ad, ha, mse_ad)
+  do n = nsteps, 0, -1
+     call fautodiff_stack_pop_r(h)
+     if (n /= nsteps) then
+        hn_ad = h_ad
+        h_ad = 0.0_dp
+        call rk4_step_rev_ad(h, h_ad, hn_ad, u, u_ad, v, v_ad, lat)
+     end if
+     if (output_interval /= -1) then
+        if (output_interval == 0) then
+           if (n == 0) call write_snapshot(n, h_ad, u, v)
+        else if (mod(n, output_interval) == 0) then
+           call write_snapshot(n, h_ad, u, v)
+        end if
+     end if
+  end do
+  grad_dot_d = sum(h_ad*d)
+  print *, sum(h_ad), minval(h_ad), maxval(h_ad)
+  print *, grad_dot_d
+  call init_variables_rev_ad()
+  call finalize_variables()
+
+contains
+
+  subroutine init_geostrophic_height(h, lon, lat)
+    real(dp), intent(out) :: h(nlon,nlat)
+    real(dp), intent(in) :: lon(nlon), lat(nlat)
+    real(dp), parameter :: u0 = 20.d0
+    real(dp) :: coeff
+    integer :: i, j
+    coeff = radius*u0*omega/g + 0.5d0*u0*u0/g
+    do j = 1, nlat
+       do i = 1, nlon
+          h(i,j) = h0 - coeff * cos(lat(j))**2
+       end do
+    end do
+  end subroutine init_geostrophic_height
+
+  subroutine geostrophic_velocity(u, v, lat)
+    real(dp), intent(out) :: u(nlon+1,nlat), v(nlon,nlat+1)
+    real(dp), intent(in) :: lat(nlat)
+    real(dp), parameter :: u0 = 20.d0
+    integer :: i, j
+    do j = 1, nlat
+       do i = 1, nlon+1
+          u(i,j) = u0 * cos(lat(j))
+       end do
+    end do
+    v = 0.d0
+  end subroutine geostrophic_velocity
+
+end program shallow_water_test2_reverse

--- a/tests/adjoint_test2.py
+++ b/tests/adjoint_test2.py
@@ -1,0 +1,70 @@
+import numpy as np
+import subprocess
+from pathlib import Path
+
+
+def save_field(path, arr):
+    path = Path(path)
+    arr.ravel(order='F').astype(np.float64).tofile(path)
+
+
+def read_snapshot(path, nlon, nlat):
+    path = Path(path)
+    data = np.fromfile(path, dtype=np.float32, count=nlon*nlat)
+    return data.reshape((nlon, nlat), order='F').astype(np.float64)
+
+
+def geostrophic_height(nlon, nlat):
+    pi = np.pi
+    radius = 6371220.0
+    g = 9.80616
+    day = 86400.0
+    omega = 2.0 * pi / (12.0 * day)
+    h0 = 10000.0
+    u0 = 20.0
+    dlat = pi / nlat
+    lat = -pi/2 + (np.arange(nlat) + 0.5) * dlat
+    coeff = (radius * u0 * omega / g) + (0.5 * u0 * u0 / g)
+    hlat = h0 - coeff * np.cos(lat) ** 2
+    return np.repeat(hlat[np.newaxis, :], nlon, axis=0)
+
+
+def main():
+    build_dir = Path(__file__).resolve().parents[1] / 'build'
+    exe_fwd = build_dir / 'shallow_water_test2_forward.out'
+    exe_rev = build_dir / 'shallow_water_test2_reverse.out'
+
+    nlon, nlat = 128, 64
+    rng = np.random.default_rng(0)
+    x = geostrophic_height(nlon, nlat)
+    u = rng.standard_normal((nlon, nlat))
+    v = rng.standard_normal()
+
+    x_file = build_dir / 'x2.bin'
+    u_file = build_dir / 'u2.bin'
+    save_field(x_file, x)
+    save_field(u_file, u)
+
+    res = subprocess.run(
+        [str(exe_fwd), '0', '-1', str(x_file), str(u_file)],
+        check=True, cwd=build_dir, capture_output=True, text=True
+    )
+    Ju = float(res.stdout.strip().split()[0])
+
+    subprocess.run(
+        [str(exe_rev), '0', '0', str(x_file)],
+        check=True, cwd=build_dir, capture_output=True, text=True
+    )
+    g = read_snapshot(build_dir / 'snapshot_0000.bin', nlon, nlat)
+
+    JT_v = v * g
+    lhs = v * Ju
+    rhs = np.vdot(u.ravel(order='F'), JT_v.ravel(order='F'))
+    diff = abs(lhs - rhs)
+    tol = max(1e-12, 1e-6 * max(abs(lhs), abs(rhs)))
+    print(f"vTJu={lhs:.6e} uTJTv={rhs:.6e} diff={diff:.6e}")
+    assert diff < tol
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/taylor_test2.py
+++ b/tests/taylor_test2.py
@@ -1,0 +1,90 @@
+import numpy as np
+import subprocess
+from pathlib import Path
+
+
+def save_field(path, arr):
+    path = Path(path)
+    arr.ravel(order='F').astype(np.float64).tofile(path)
+
+
+def read_cost(path):
+    path = Path(path)
+    with path.open() as f:
+        for line in f:
+            if line.startswith('MSE'):
+                return float(line.split()[1])
+    raise RuntimeError('MSE not found')
+
+
+def geostrophic_height(nlon, nlat):
+    pi = np.pi
+    radius = 6371220.0
+    g = 9.80616
+    day = 86400.0
+    omega = 2.0 * pi / (12.0 * day)
+    h0 = 10000.0
+    u0 = 20.0
+    dlon = 2.0 * pi / nlon
+    dlat = pi / nlat
+    lat = -pi/2 + (np.arange(nlat) + 0.5) * dlat
+    coeff = (radius * u0 * omega / g) + (0.5 * u0 * u0 / g)
+    hlat = h0 - coeff * np.cos(lat) ** 2
+    return np.repeat(hlat[np.newaxis, :], nlon, axis=0)
+
+
+def main():
+    build_dir = Path(__file__).resolve().parents[1] / 'build'
+    exe_base = build_dir / 'shallow_water_test2.out'
+    exe_fwd = build_dir / 'shallow_water_test2_forward.out'
+    exe_rev = build_dir / 'shallow_water_test2_reverse.out'
+
+    nlon, nlat = 128, 64
+    rng = np.random.default_rng(0)
+    x = geostrophic_height(nlon, nlat)
+    d = rng.standard_normal((nlon, nlat))
+
+    x_file = build_dir / 'x2.bin'
+    d_file = build_dir / 'd2.bin'
+    save_field(x_file, x)
+    save_field(d_file, d)
+
+    subprocess.run([str(exe_base), '0', '0', str(x_file)], check=True, cwd=build_dir)
+    F0 = read_cost(build_dir / 'cost.log')
+    assert F0 < 1e-8
+
+    eps_list = np.logspace(-1, -5, num=5)
+    diffs = []
+    for i, eps in enumerate(eps_list):
+        x_eps = x + eps * d
+        x_eps_file = build_dir / f'x2_eps_{i}.bin'
+        save_field(x_eps_file, x_eps)
+        subprocess.run([str(exe_base), '0', '0', str(x_eps_file)], check=True, cwd=build_dir)
+        Fe = read_cost(build_dir / 'cost.log')
+        diffs.append((Fe - F0) / eps)
+    diffs = np.array(diffs)
+
+    res = subprocess.run([str(exe_fwd), '0', '0', str(x_file), str(d_file)],
+                         check=True, cwd=build_dir, capture_output=True, text=True)
+    mse_ad = float(res.stdout.strip().split()[0])
+
+    res = subprocess.run([str(exe_rev), '0', '0', str(x_file), str(d_file)],
+                         check=True, cwd=build_dir, capture_output=True, text=True)
+    lines = res.stdout.strip().splitlines()
+    grad_dot_d = float(lines[-1].split()[0])
+
+    fwd_err = np.abs(mse_ad - diffs)
+    rev_err = np.abs(grad_dot_d - diffs)
+
+    for eps, diff, fe, re in zip(eps_list, diffs, fwd_err, rev_err):
+        print(f"eps={eps:.1e} diff={diff:.6e} fwd_err={fe:.6e} rev_err={re:.6e}")
+
+    np.savez(build_dir / 'taylor_test2_results.npz', eps=eps_list, diff=diffs,
+             fwd=fwd_err, rev=rev_err)
+
+    assert fwd_err[2] < fwd_err[0]
+    assert rev_err[2] < rev_err[0]
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add steady geostrophic flow program and AD-enabled drivers
- extend build system for new test case
- add Taylor expansion and duality tests for test case 2

## Testing
- `python tests/taylor_test2.py`
- `python tests/adjoint_test2.py`
- `python tests/taylor_test1.py`
- `python tests/adjoint_test1.py`


------
https://chatgpt.com/codex/tasks/task_b_689168972e88832db80d7ea674f61a1a