### PR TITLE
Add Coriolis-driven velocity evolution

### DIFF
--- a/src/common/io_module.f90
+++ b/src/common/io_module.f90
@@ -63,10 +63,10 @@ contains
   subroutine write_snapshot(n, h, u, v)
     integer, intent(in) :: n
     real(dp), intent(in) :: h(nlon,nlat)
-    real(dp), intent(in) :: u(nlon+1,nlat), v(nlon,nlat+1)
+    real(dp), intent(in) :: u(nlon,nlat), v(nlon,nlat+1)
     character(len=32) :: filename
     hsp = real(h,sp)
-    usp = real(0.5d0*(u(1:nlon,:) + u(2:nlon+1,:)), sp)
+    usp = real(0.5d0*(u + cshift(u,1,dim=1)), sp)
     vsp = real(0.5d0*(v(:,1:nlat) + v(:,2:nlat+1)), sp)
     write(filename,'("snapshot_",i4.4,".bin")') n
     open(unit=20,file=filename,form='unformatted',access='stream',status='replace')

--- a/src/common/rk4_module.f90
+++ b/src/common/rk4_module.f90
@@ -6,20 +6,32 @@ module rk4_module
 contains
 
   !$FAD CONSTANT_VARS: lat
-  subroutine rk4_step(h,hn,u,v,lat)
-    real(dp), intent(in) :: h(nlon,nlat), u(nlon+1,nlat), v(nlon,nlat+1), lat(nlat)
-    real(dp), intent(out) :: hn(nlon,nlat)
-    real(dp) :: k1(nlon,nlat), k2(nlon,nlat)
-    real(dp) :: k3(nlon,nlat), k4(nlon,nlat)
-    real(dp) :: htmp(nlon,nlat)
-    call rhs(h, k1, u, v, lat)
-    htmp = h + 0.5d0*dt*k1
-    call rhs(htmp, k2, u, v, lat)
-    htmp = h + 0.5d0*dt*k2
-    call rhs(htmp, k3, u, v, lat)
-    htmp = h + dt*k3
-    call rhs(htmp, k4, u, v, lat)
-    hn = h + dt*(k1 + 2.d0*k2 + 2.d0*k3 + k4)/6.d0
+  subroutine rk4_step(h,u,v,hn,un,vn,lat)
+    real(dp), intent(in) :: h(nlon,nlat), u(nlon,nlat), v(nlon,nlat+1)
+    real(dp), intent(out) :: hn(nlon,nlat), un(nlon,nlat), vn(nlon,nlat+1)
+    real(dp), intent(in) :: lat(nlat)
+    real(dp) :: k1h(nlon,nlat), k2h(nlon,nlat), k3h(nlon,nlat), k4h(nlon,nlat)
+    real(dp) :: k1u(nlon,nlat), k2u(nlon,nlat), k3u(nlon,nlat), k4u(nlon,nlat)
+    real(dp) :: k1v(nlon,nlat+1), k2v(nlon,nlat+1), k3v(nlon,nlat+1), k4v(nlon,nlat+1)
+    real(dp) :: htmp(nlon,nlat), utmp(nlon,nlat), vtmp(nlon,nlat+1)
+    call rhs(h, u, v, k1h, k1u, k1v, lat)
+    htmp = h + 0.5d0*dt*k1h
+    utmp = u + 0.5d0*dt*k1u
+    vtmp = v + 0.5d0*dt*k1v
+    call rhs(htmp, utmp, vtmp, k2h, k2u, k2v, lat)
+    htmp = h + 0.5d0*dt*k2h
+    utmp = u + 0.5d0*dt*k2u
+    vtmp = v + 0.5d0*dt*k2v
+    call rhs(htmp, utmp, vtmp, k3h, k3u, k3v, lat)
+    htmp = h + dt*k3h
+    utmp = u + dt*k3u
+    vtmp = v + dt*k3v
+    call rhs(htmp, utmp, vtmp, k4h, k4u, k4v, lat)
+    hn = h + dt*(k1h + 2.d0*k2h + 2.d0*k3h + k4h)/6.d0
+    un = u + dt*(k1u + 2.d0*k2u + 2.d0*k3u + k4u)/6.d0
+    vn = v + dt*(k1v + 2.d0*k2v + 2.d0*k3v + k4v)/6.d0
+    vn(:,1) = 0.d0
+    vn(:,nlat+1) = 0.d0
   end subroutine rk4_step
 
 end module rk4_module

--- a/src/common/variables_module.f90
+++ b/src/common/variables_module.f90
@@ -26,7 +26,7 @@ contains
     integer :: i, j
     allocate(lon(nlon), lat(nlat))
     allocate(h(nlon,nlat), hn(nlon,nlat), ha(nlon,nlat))
-    allocate(u(nlon+1,nlat), v(nlon,nlat+1))
+    allocate(u(nlon,nlat), v(nlon,nlat+1))
     allocate(hsp(nlon,nlat), usp(nlon,nlat), vsp(nlon,nlat))
     do i=1,nlon
        lon(i) = (i-0.5d0)*dlon

--- a/src/testcase1/shallow_water_test1.f90
+++ b/src/testcase1/shallow_water_test1.f90
@@ -9,6 +9,7 @@ program shallow_water_test1
 
   real(dp) :: t, maxerr, l1err, l2err, alpha, mse, mass_res
   integer :: n
+  real(dp) :: un(nlon,nlat), vn(nlon,nlat+1)
   character(len=256) :: carg
 
   call init_variables()
@@ -37,8 +38,10 @@ program shallow_water_test1
         end if
      end if
      if (n == nsteps) exit
-     call rk4_step(h, hn, u, v, lat)
+     call rk4_step(h, u, v, hn, un, vn, lat)
      h = hn
+     u = un
+     v = vn
   end do
   call close_error_file()
   mse = calc_mse(h, ha)

--- a/src/testcase1/shallow_water_test1_forward.f90
+++ b/src/testcase1/shallow_water_test1_forward.f90
@@ -14,6 +14,8 @@ program shallow_water_test1_forward
   real(dp) :: t_ad, maxerr_ad, l1err_ad, l2err_ad, mse_ad, mass_res_ad
   integer :: n
   character(len=256) :: carg
+  real(dp) :: un(nlon,nlat), vn(nlon,nlat+1)
+  real(dp) :: un_ad(nlon,nlat), vn_ad(nlon,nlat+1)
 
   call init_variables()
   call read_alpha(alpha)
@@ -46,9 +48,13 @@ program shallow_water_test1_forward
         end if
      end if
      if (n == nsteps) exit
-     call rk4_step_fwd_ad(h, h_ad, hn, hn_ad, u, u_ad, v, v_ad, lat)
+     call rk4_step_fwd_ad(h, h_ad, u, u_ad, v, v_ad, hn, hn_ad, un, un_ad, vn, vn_ad, lat)
      h_ad = hn_ad
+     u_ad = un_ad
+     v_ad = vn_ad
      h = hn
+     u = un
+     v = vn
   end do
   t = nsteps*dt
   call analytic_height(ha, lon, lat, t, alpha)

--- a/tests/adjoint_test2.py
+++ b/tests/adjoint_test2.py
@@ -24,8 +24,8 @@ def geostrophic_height(nlon, nlat):
     u0 = 20.0
     dlat = pi / nlat
     lat = -pi/2 + (np.arange(nlat) + 0.5) * dlat
-    coeff = (radius * u0 * omega / g) + (0.5 * u0 * u0 / g)
-    hlat = h0 - coeff * np.cos(lat) ** 2
+    coeff = radius * omega * u0 / g
+    hlat = h0 - coeff * np.sin(lat) ** 2
     return np.repeat(hlat[np.newaxis, :], nlon, axis=0)
 
 

--- a/tests/taylor_test2.py
+++ b/tests/taylor_test2.py
@@ -28,8 +28,8 @@ def geostrophic_height(nlon, nlat):
     dlon = 2.0 * pi / nlon
     dlat = pi / nlat
     lat = -pi/2 + (np.arange(nlat) + 0.5) * dlat
-    coeff = (radius * u0 * omega / g) + (0.5 * u0 * u0 / g)
-    hlat = h0 - coeff * np.cos(lat) ** 2
+    coeff = radius * omega * u0 / g
+    hlat = h0 - coeff * np.sin(lat) ** 2
     return np.repeat(hlat[np.newaxis, :], nlon, axis=0)
 
 


### PR DESCRIPTION
## Summary
- Advance zonal and meridional velocities through time and add Coriolis terms
- Extend RK4 integrator to evolve height and velocity together
- Base testcase2 on geostrophic balance using the Coriolis force and update tests accordingly
- Correct staggered-grid momentum discretization and initialize adjoint velocity fields
- Resize zonal velocity arrays and streamline meridional momentum indexing

## Testing
- `make`
- `pytest -q` *(fails: mpifort: No such file or directory; FileNotFoundError: examples/module_vars.f90)*

------
https://chatgpt.com/codex/tasks/task_b_68917de97088832d9e6512140e4e71f5