### PR TITLE
Avoid running external fautodiff tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,4 @@
+# AGENTS
+
+- Run tests with `pytest`.
+- The repository may clone the external library `fautodiff` into `scripts/fautodiff`. Its tests are unrelated to this project and should not be executed. `pytest` is configured to run only the tests under the `tests/` directory.

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+testpaths = tests
+norecursedirs = scripts/fautodiff


### PR DESCRIPTION
## Summary
- document that the cloned `fautodiff` library's tests should not run
- configure pytest to only search the repository's `tests` directory and ignore `scripts/fautodiff`

## Testing
- `pytest` (no tests ran)


------
https://chatgpt.com/codex/tasks/task_b_68918a69e95c832da3cfe17541b51ce0