### PR TITLE
Set zero gravity and Coriolis in testcase1

### DIFF
--- a/src/common/rk4_module.f90
+++ b/src/common/rk4_module.f90
@@ -5,28 +5,49 @@ module rk4_module
   implicit none
 contains
 
-  !$FAD CONSTANT_VARS: lat
-  subroutine rk4_step(h,u,v,hn,un,vn,lat)
+  !$FAD CONSTANT_VARS: lat, no_momentum_tendency
+  subroutine rk4_step(h,u,v,hn,un,vn,lat,no_momentum_tendency)
     real(dp), intent(in) :: h(nlon,nlat), u(nlon,nlat), v(nlon,nlat+1)
     real(dp), intent(out) :: hn(nlon,nlat), un(nlon,nlat), vn(nlon,nlat+1)
     real(dp), intent(in) :: lat(nlat)
+    logical, intent(in), optional :: no_momentum_tendency
     real(dp) :: k1h(nlon,nlat), k2h(nlon,nlat), k3h(nlon,nlat), k4h(nlon,nlat)
     real(dp) :: k1u(nlon,nlat), k2u(nlon,nlat), k3u(nlon,nlat), k4u(nlon,nlat)
     real(dp) :: k1v(nlon,nlat+1), k2v(nlon,nlat+1), k3v(nlon,nlat+1), k4v(nlon,nlat+1)
     real(dp) :: htmp(nlon,nlat), utmp(nlon,nlat), vtmp(nlon,nlat+1)
-    call rhs(h, u, v, k1h, k1u, k1v, lat)
+    logical :: skip_momentum
+    skip_momentum = .false.
+    if (present(no_momentum_tendency)) skip_momentum = no_momentum_tendency
+
+    if (skip_momentum) then
+       call rhs(h, u, v, k1h, k1u, k1v, lat, no_momentum_tendency=.true.)
+       htmp = h + 0.5d0*dt*k1h
+       call rhs(htmp, u, v, k2h, k2u, k2v, lat, no_momentum_tendency=.true.)
+       htmp = h + 0.5d0*dt*k2h
+       call rhs(htmp, u, v, k3h, k3u, k3v, lat, no_momentum_tendency=.true.)
+       htmp = h + dt*k3h
+       call rhs(htmp, u, v, k4h, k4u, k4v, lat, no_momentum_tendency=.true.)
+       hn = h + dt*(k1h + 2.d0*k2h + 2.d0*k3h + k4h)/6.d0
+       un = u
+       vn = v
+       vn(:,1) = 0.d0
+       vn(:,nlat+1) = 0.d0
+       return
+    end if
+
+    call rhs(h, u, v, k1h, k1u, k1v, lat, no_momentum_tendency=.false.)
     htmp = h + 0.5d0*dt*k1h
     utmp = u + 0.5d0*dt*k1u
     vtmp = v + 0.5d0*dt*k1v
-    call rhs(htmp, utmp, vtmp, k2h, k2u, k2v, lat)
+    call rhs(htmp, utmp, vtmp, k2h, k2u, k2v, lat, no_momentum_tendency=.false.)
     htmp = h + 0.5d0*dt*k2h
     utmp = u + 0.5d0*dt*k2u
     vtmp = v + 0.5d0*dt*k2v
-    call rhs(htmp, utmp, vtmp, k3h, k3u, k3v, lat)
+    call rhs(htmp, utmp, vtmp, k3h, k3u, k3v, lat, no_momentum_tendency=.false.)
     htmp = h + dt*k3h
     utmp = u + dt*k3u
     vtmp = v + dt*k3v
-    call rhs(htmp, utmp, vtmp, k4h, k4u, k4v, lat)
+    call rhs(htmp, utmp, vtmp, k4h, k4u, k4v, lat, no_momentum_tendency=.false.)
     hn = h + dt*(k1h + 2.d0*k2h + 2.d0*k3h + k4h)/6.d0
     un = u + dt*(k1u + 2.d0*k2u + 2.d0*k3u + k4u)/6.d0
     vn = v + dt*(k1v + 2.d0*k2v + 2.d0*k3v + k4v)/6.d0

--- a/src/common/variables_module.f90
+++ b/src/common/variables_module.f90
@@ -3,11 +3,12 @@ module variables_module
   implicit none
   integer, parameter :: nlon=128, nlat=64
   real(dp), parameter :: pi=3.14159265358979323846d0
-  real(dp), parameter :: radius=6371220.d0, g=9.80616d0
+  real(dp), parameter :: radius=6371220.d0
+  real(dp) :: g=9.80616d0
   real(dp), parameter :: day=86400.d0
   real(dp), parameter :: dlon=2.d0*pi/nlon, dlat=pi/nlat
   real(dp), parameter :: h0=10000.d0, h1=2000.d0
-  real(dp), parameter :: omega=2.d0*pi/(12.d0*day)
+  real(dp) :: omega=2.d0*pi/(12.d0*day)
   real(dp), parameter :: dt=600.d0
   integer, parameter :: nsteps=nint(12.d0*day/dt)
   integer :: output_interval=48
@@ -19,6 +20,7 @@ module variables_module
   !$FAD CONSTANT_VARS: lon, lat
   !$FAD CONSTANT_VARS: ha
   !$FAD CONSTANT_VARS: hsp, usp, vsp
+  !$FAD CONSTANT_VARS: g, omega
 
 contains
 

--- a/src/testcase1/shallow_water_test1.f90
+++ b/src/testcase1/shallow_water_test1.f90
@@ -38,7 +38,7 @@ program shallow_water_test1
         end if
      end if
      if (n == nsteps) exit
-     call rk4_step(h, u, v, hn, un, vn, lat)
+     call rk4_step(h, u, v, hn, un, vn, lat, no_momentum_tendency=.true.)
      h = hn
      u = un
      v = vn

--- a/src/testcase1/shallow_water_test1_forward.f90
+++ b/src/testcase1/shallow_water_test1_forward.f90
@@ -48,7 +48,7 @@ program shallow_water_test1_forward
         end if
      end if
      if (n == nsteps) exit
-     call rk4_step_fwd_ad(h, h_ad, u, u_ad, v, v_ad, hn, hn_ad, un, un_ad, vn, vn_ad, lat)
+     call rk4_step_fwd_ad(h, h_ad, u, u_ad, v, v_ad, hn, hn_ad, un, un_ad, vn, vn_ad, lat, no_momentum_tendency=.true.)
      h_ad = hn_ad
      u_ad = un_ad
      v_ad = vn_ad

--- a/src/testcase1/shallow_water_test1_reverse.f90
+++ b/src/testcase1/shallow_water_test1_reverse.f90
@@ -46,7 +46,7 @@ program shallow_water_test1_reverse
      call fautodiff_stack_push_r(u)
      call fautodiff_stack_push_r(v)
      if (n == nsteps) exit
-     call rk4_step(h, u, v, hn, un, vn, lat)
+     call rk4_step(h, u, v, hn, un, vn, lat, no_momentum_tendency=.true.)
      h = hn
      u = un
      v = vn
@@ -77,7 +77,7 @@ program shallow_water_test1_reverse
         h_ad = 0.0_dp
         u_ad = 0.0_dp
         v_ad = 0.0_dp
-        call rk4_step_rev_ad(h, h_ad, u, u_ad, v, v_ad, hn_ad, un_ad, vn_ad, lat)
+        call rk4_step_rev_ad(h, h_ad, u, u_ad, v, v_ad, hn_ad, un_ad, vn_ad, lat, no_momentum_tendency=.true.)
      end if
      if (output_interval /= -1) then
         if (output_interval == 0) then


### PR DESCRIPTION
## Summary
- Add a `no_momentum_tendency` option to `rhs` that zeros `dudt`/`dvdt` and returns before the momentum equations
- Allow `rk4_step` to skip momentum updates when `no_momentum_tendency` is set
- Run testcase1 drivers with `no_momentum_tendency=.true.` instead of altering gravity or Coriolis parameters

## Testing
- `make -C build`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68919472e910832db89ac164fa986ba7