### PR TITLE
Handle near-zero Coriolis terms in geostrophic adjoint

### DIFF
--- a/src/testcase2/shallow_water_test2_forward.f90
+++ b/src/testcase2/shallow_water_test2_forward.f90
@@ -94,6 +94,7 @@ contains
     real(dp), parameter :: u0 = 20.d0
     integer :: i, j, ip1, im1, jp1, jm1
     real(dp) :: fcor
+    real(dp) :: fcor_eff
     real(dp), parameter :: eps = 1.0e-6_dp
 
     do j = 1, nlat
@@ -108,25 +109,23 @@ contains
        jp1 = j + 1
        jm1 = j - 1
        fcor = 2.d0*omega*sin(lat(j))
-       if (abs(fcor) > eps) then
-          do i = 1, nlon
-             u_ad(i,j) = -(g/fcor) * (h_ad(i,jp1) - h_ad(i,jm1)) / &
-                          & (2.d0*dlat*radius)
-          end do
-       end if
+       fcor_eff = sign(max(abs(fcor), eps), fcor)
+       do i = 1, nlon
+          u_ad(i,j) = -(g/fcor_eff) * (h_ad(i,jp1) - h_ad(i,jm1)) / &
+                       & (2.d0*dlat*radius)
+       end do
     end do
 
     v_ad = 0.d0
     do j = 2, nlat
        fcor = 2.d0*omega*sin(lat(j))
-       if (abs(fcor) > eps) then
-          do i = 1, nlon
-             ip1 = mod(i, nlon) + 1
-             im1 = mod(i-2 + nlon, nlon) + 1
-             v_ad(i,j) = (g/fcor) * (h_ad(ip1,j) - h_ad(im1,j)) / &
-                          & (2.d0*dlon*radius*cos(lat(j)))
-          end do
-       end if
+       fcor_eff = sign(max(abs(fcor), eps), fcor)
+       do i = 1, nlon
+          ip1 = mod(i, nlon) + 1
+          im1 = mod(i-2 + nlon, nlon) + 1
+          v_ad(i,j) = (g/fcor_eff) * (h_ad(ip1,j) - h_ad(im1,j)) / &
+                       & (2.d0*dlon*radius*cos(lat(j)))
+       end do
     end do
     v_ad(:,1) = 0.d0
     v_ad(:,nlat+1) = 0.d0


### PR DESCRIPTION
## Summary
- Always compute adjoint velocities in `geostrophic_velocity_fwd_ad` using an effective Coriolis term (`fcor_eff`) instead of skipping updates when `|fcor|` is small

## Testing
- `make` (builds all targets)
- `shallow_water_test2_forward.out 0 -1 build/x2.bin build/u2.bin` *(fails: Floating point exception)*
- `pytest` *(no tests collected)*

------
https://chatgpt.com/codex/tasks/task_b_68931594afa4832db5a76b6497cc79a3