### PR TITLE
Adjust command-line arguments after removing alpha

### DIFF
--- a/src/common/io_module.f90
+++ b/src/common/io_module.f90
@@ -20,8 +20,8 @@ contains
   subroutine read_output_interval(interval)
     integer, intent(inout) :: interval
     character(len=32) :: carg
-    if (command_argument_count() >= 2) then
-       call get_command_argument(2,carg)
+    if (command_argument_count() >= 1) then
+       call get_command_argument(1,carg)
        read(carg,*) interval
     end if
   end subroutine read_output_interval

--- a/src/testcase1/shallow_water_test1.f90
+++ b/src/testcase1/shallow_water_test1.f90
@@ -7,17 +7,16 @@ program shallow_water_test1
   use io_module
   implicit none
 
-  real(dp) :: t, maxerr, l1err, l2err, alpha, mse, mass_res
+  real(dp) :: t, maxerr, l1err, l2err, mse, mass_res
   integer :: n
   real(dp) :: un(nx,ny), vn(nx,ny+1)
   character(len=256) :: carg
 
   call init_variables()
-  call read_alpha(alpha)
   call read_output_interval(output_interval)
   call write_grid_params()
-  if (command_argument_count() >= 3) then
-     call get_command_argument(3, carg)
+  if (command_argument_count() >= 2) then
+     call get_command_argument(2, carg)
      call read_field(h, trim(carg))
   else
      call init_height(h, x, y)

--- a/src/testcase1/shallow_water_test1_forward.f90
+++ b/src/testcase1/shallow_water_test1_forward.f90
@@ -10,7 +10,7 @@ program shallow_water_test1_forward
   use io_module
   implicit none
 
-  real(dp) :: t, maxerr, l1err, l2err, alpha, mse, mass_res
+  real(dp) :: t, maxerr, l1err, l2err, mse, mass_res
   real(dp) :: t_ad, maxerr_ad, l1err_ad, l2err_ad, mse_ad, mass_res_ad
   integer :: n
   character(len=256) :: carg
@@ -18,18 +18,17 @@ program shallow_water_test1_forward
   real(dp) :: un_ad(nx,ny), vn_ad(nx,ny+1)
 
   call init_variables()
-  call read_alpha(alpha)
   call read_output_interval(output_interval)
   call write_grid_params()
   call init_variables_fwd_ad()
-  if (command_argument_count() >= 3) then
-     call get_command_argument(3, carg)
+  if (command_argument_count() >= 2) then
+     call get_command_argument(2, carg)
      call read_field(h, trim(carg))
   else
      call init_height(h, x, y)
   end if
-  if (command_argument_count() >= 4) then
-     call get_command_argument(4, carg)
+  if (command_argument_count() >= 3) then
+     call get_command_argument(3, carg)
      call read_field(h_ad, trim(carg))
   else
      h_ad(nx/2,ny/2) = 1.0_dp

--- a/src/testcase1/shallow_water_test1_reverse.f90
+++ b/src/testcase1/shallow_water_test1_reverse.f90
@@ -13,7 +13,7 @@ program shallow_water_test1_reverse
   use fautodiff_stack
   implicit none
 
-  real(dp) :: t, maxerr, l1err, l2err, alpha, mse, mass_res
+  real(dp) :: t, maxerr, l1err, l2err, mse, mass_res
   real(dp) :: maxerr_ad, l1err_ad, l2err_ad, mse_ad, mass_res_ad
   real(dp) :: grad_dot_d
   integer :: n
@@ -23,18 +23,17 @@ program shallow_water_test1_reverse
   real(dp) :: un_ad(nx,ny), vn_ad(nx,ny+1)
 
   call init_variables()
-  call read_alpha(alpha)
   call read_output_interval(output_interval)
   call write_grid_params()
-  if (command_argument_count() >= 3) then
-     call get_command_argument(3, carg)
+  if (command_argument_count() >= 2) then
+     call get_command_argument(2, carg)
      call read_field(h, trim(carg))
   else
      call init_height(h, x, y)
   end if
   allocate(d(nx,ny))
-  if (command_argument_count() >= 4) then
-     call get_command_argument(4, carg)
+  if (command_argument_count() >= 3) then
+     call get_command_argument(3, carg)
      call read_field(d, trim(carg))
   else
      d = 0.0_dp

--- a/src/testcase2/shallow_water_test2.f90
+++ b/src/testcase2/shallow_water_test2.f90
@@ -15,8 +15,8 @@ program shallow_water_test2
   call read_output_interval(output_interval)
   call write_grid_params()
 
-  if (command_argument_count() >= 3) then
-     call get_command_argument(3, carg)
+  if (command_argument_count() >= 2) then
+     call get_command_argument(2, carg)
      call read_field(h, trim(carg))
      ha = h
   else

--- a/src/testcase2/shallow_water_test2_forward.f90
+++ b/src/testcase2/shallow_water_test2_forward.f90
@@ -23,16 +23,16 @@ program shallow_water_test2_forward
   call write_grid_params()
   call init_variables_fwd_ad()
   ha = 0.0_dp
-  if (command_argument_count() >= 3) then
-     call get_command_argument(3, carg)
+  if (command_argument_count() >= 2) then
+     call get_command_argument(2, carg)
      call read_field(h, trim(carg))
      ha = h
   else
      call init_geostrophic_height_fwd_ad(h, h_ad, y)
      ha = h
   end if
-  if (command_argument_count() >= 4) then
-     call get_command_argument(4, carg)
+  if (command_argument_count() >= 3) then
+     call get_command_argument(3, carg)
      call read_field(h_ad, trim(carg))
   else
      h_ad(nx/2-1:nx/2+2, ny/2-1:ny/2+2) = 0.5_dp

--- a/src/testcase2/shallow_water_test2_reverse.f90
+++ b/src/testcase2/shallow_water_test2_reverse.f90
@@ -24,16 +24,16 @@ program shallow_water_test2_reverse
   call init_variables()
   call read_output_interval(output_interval)
   call write_grid_params()
-  if (command_argument_count() >= 3) then
-     call get_command_argument(3, carg)
+  if (command_argument_count() >= 2) then
+     call get_command_argument(2, carg)
      call read_field(h, trim(carg))
   else
      call init_geostrophic_height(h, y)
   end if
   ha = h
   allocate(d(nx,ny))
-  if (command_argument_count() >= 4) then
-     call get_command_argument(4, carg)
+  if (command_argument_count() >= 3) then
+     call get_command_argument(3, carg)
      call read_field(d, trim(carg))
   else
      d = 0.0_dp

--- a/tests/adjoint_test1.py
+++ b/tests/adjoint_test1.py
@@ -28,13 +28,13 @@ def main():
     save_field(u_file, u)
 
     res = subprocess.run(
-        [str(exe_fwd), '0', '-1', str(x_file), str(u_file)],
+        [str(exe_fwd), '-1', str(x_file), str(u_file)],
         check=True, cwd=build_dir, capture_output=True, text=True
     )
     Ju = float(res.stdout.strip().split()[0])
 
     subprocess.run(
-        [str(exe_rev), '0', '0', str(x_file)],
+        [str(exe_rev), '0', str(x_file)],
         check=True, cwd=build_dir, capture_output=True, text=True
     )
     g = read_snapshot(build_dir / 'snapshot_0000.bin', nlon, nlat)

--- a/tests/adjoint_test2.py
+++ b/tests/adjoint_test2.py
@@ -46,13 +46,13 @@ def main():
     save_field(u_file, u)
 
     res = subprocess.run(
-        [str(exe_fwd), '0', '-1', str(x_file), str(u_file)],
+        [str(exe_fwd), '-1', str(x_file), str(u_file)],
         check=True, cwd=build_dir, capture_output=True, text=True
     )
     Ju = float(res.stdout.strip().split()[0])
 
     subprocess.run(
-        [str(exe_rev), '0', '0', str(x_file)],
+        [str(exe_rev), '0', str(x_file)],
         check=True, cwd=build_dir, capture_output=True, text=True
     )
     g = read_snapshot(build_dir / 'snapshot_0000.bin', nlon, nlat)

--- a/tests/taylor_test1.py
+++ b/tests/taylor_test1.py
@@ -30,7 +30,7 @@ def main():
     save_field(x_file, x)
     save_field(d_file, d)
 
-    subprocess.run([str(exe_base), '0', '0', str(x_file)], check=True, cwd=build_dir)
+    subprocess.run([str(exe_base), '0', str(x_file)], check=True, cwd=build_dir)
     F0 = read_cost(build_dir / 'cost.log')
 
     eps_list = np.logspace(-1, -5, num=5)
@@ -39,16 +39,16 @@ def main():
         x_eps = x + eps * d
         x_eps_file = build_dir / f'x_eps_{i}.bin'
         save_field(x_eps_file, x_eps)
-        subprocess.run([str(exe_base), '0', '0', str(x_eps_file)], check=True, cwd=build_dir)
+        subprocess.run([str(exe_base), '0', str(x_eps_file)], check=True, cwd=build_dir)
         Fe = read_cost(build_dir / 'cost.log')
         diffs.append((Fe - F0) / eps)
     diffs = np.array(diffs)
 
-    res = subprocess.run([str(exe_fwd), '0', '0', str(x_file), str(d_file)],
+    res = subprocess.run([str(exe_fwd), '0', str(x_file), str(d_file)],
                          check=True, cwd=build_dir, capture_output=True, text=True)
     mse_ad = float(res.stdout.strip().split()[0])
 
-    res = subprocess.run([str(exe_rev), '0', '0', str(x_file), str(d_file)],
+    res = subprocess.run([str(exe_rev), '0', str(x_file), str(d_file)],
                          check=True, cwd=build_dir, capture_output=True, text=True)
     lines = res.stdout.strip().splitlines()
     grad_dot_d = float(lines[-1].split()[0])

--- a/tests/taylor_test2.py
+++ b/tests/taylor_test2.py
@@ -49,7 +49,7 @@ def main():
     save_field(x_file, x)
     save_field(d_file, d)
 
-    subprocess.run([str(exe_base), '0', '0', str(x_file)], check=True, cwd=build_dir)
+    subprocess.run([str(exe_base), '0', str(x_file)], check=True, cwd=build_dir)
     F0 = read_cost(build_dir / 'cost.log')
     assert F0 < 100.0 # 10 m
 
@@ -59,16 +59,16 @@ def main():
         x_eps = x + eps * d
         x_eps_file = build_dir / f'x2_eps_{i}.bin'
         save_field(x_eps_file, x_eps)
-        subprocess.run([str(exe_base), '0', '0', str(x_eps_file)], check=True, cwd=build_dir)
+        subprocess.run([str(exe_base), '0', str(x_eps_file)], check=True, cwd=build_dir)
         Fe = read_cost(build_dir / 'cost.log')
         diffs.append((Fe - F0) / eps)
     diffs = np.array(diffs)
 
-    res = subprocess.run([str(exe_fwd), '0', '0', str(x_file), str(d_file)],
+    res = subprocess.run([str(exe_fwd), '0', str(x_file), str(d_file)],
                          check=True, cwd=build_dir, capture_output=True, text=True)
     mse_ad = float(res.stdout.strip().split()[0])
 
-    res = subprocess.run([str(exe_rev), '0', '0', str(x_file), str(d_file)],
+    res = subprocess.run([str(exe_rev), '0', str(x_file), str(d_file)],
                          check=True, cwd=build_dir, capture_output=True, text=True)
     lines = res.stdout.strip().splitlines()
     grad_dot_d = float(lines[-1].split()[0])


### PR DESCRIPTION
## Summary
- Drop unused alpha argument from test case drivers and shift subsequent arguments down.
- Update `read_output_interval` and all testcases to read new command-line positions.
- Align Python tests with the updated argument order.

## Testing
- `make -C build`
- `pytest` (no tests discovered)


------
https://chatgpt.com/codex/tasks/task_b_689433dcbc58832d90a3a0e4f0392160