### PR TITLE
docs: describe channel flow tests based on Williamson 1992

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # shallow_water_adjoint
 Shallow water equation model with adjoint model
 
+The testcases included here follow the benchmark proposed by Williamson
+et al. (1992).  Instead of the original spherical geometry, they solve a
+channel flow in Cartesian coordinates with free-slip boundaries in the
+y direction and periodic boundaries in the x direction.
+
 The test program `shallow_water_test1` accepts two optional command-line
 arguments:
 


### PR DESCRIPTION
## Summary
- document that all shallow water testcases follow the Williamson et al. (1992) benchmark in a Cartesian channel with free-slip y and periodic x boundaries

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689449b98900832db37df8f72af32023