### PR TITLE
Add topography testcase with AD verification

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -20,7 +20,8 @@ FAUTODIFF_SRC  = fautodiff_stack.f90
 VPATH = ../src/common
 
 all: shallow_water_test1.out shallow_water_test1_forward.out shallow_water_test1_reverse.out \
-     shallow_water_test2.out shallow_water_test2_forward.out shallow_water_test2_reverse.out
+     shallow_water_test2.out shallow_water_test2_forward.out shallow_water_test2_reverse.out \
+     shallow_water_test5.out shallow_water_test5_forward.out shallow_water_test5_reverse.out
 
 shallow_water_test1.out: ../src/testcase1/shallow_water_test1.f90 $(COMMON_OBJS)
 >$(FC) $(FFLAGS) -o $@ $^
@@ -38,6 +39,15 @@ shallow_water_test2_forward.out: ../src/testcase2/shallow_water_test2_forward.f9
 >$(FC) $(FFLAGS) -I. -o $@ $^
 
 shallow_water_test2_reverse.out: ../src/testcase2/shallow_water_test2_reverse.f90 $(COMMON_OBJS) $(COMMON_AD_OBJS) $(FAUTODIFF_OBJS)
+>$(FC) $(FFLAGS) -I. -o $@ $^
+
+shallow_water_test5.out: ../src/testcase5/shallow_water_test5.f90 $(COMMON_OBJS)
+>$(FC) $(FFLAGS) -o $@ $^
+
+shallow_water_test5_forward.out: ../src/testcase5/shallow_water_test5_forward.f90 $(COMMON_OBJS) $(COMMON_AD_OBJS) $(FAUTODIFF_OBJS)
+>$(FC) $(FFLAGS) -I. -o $@ $^
+
+shallow_water_test5_reverse.out: ../src/testcase5/shallow_water_test5_reverse.f90 $(COMMON_OBJS) $(COMMON_AD_OBJS) $(FAUTODIFF_OBJS)
 >$(FC) $(FFLAGS) -I. -o $@ $^
 
 %_ad.o: %_ad.f90 $(FAUTODIFF_OBJS)

--- a/src/common/cost_module.f90
+++ b/src/common/cost_module.f90
@@ -1,7 +1,9 @@
 module cost_module
   use constants_module, only: dp
+  use variables_module, only: g
   implicit none
   real(dp), save :: reference_mass = -1.d0
+  real(dp), save :: reference_energy = -1.d0
 contains
 
   !> Compute sum of squared errors between numerical and analytic heights
@@ -24,6 +26,40 @@ contains
        residual = current_mass - reference_mass
     end if
   end function calc_mass_residual
+
+  !> Compute deviation from the initial total energy
+  function calc_energy_residual(height, u, v) result(residual)
+    real(dp), intent(in) :: height(:,:), u(:,:), v(:,:)
+    real(dp) :: residual, current_energy
+    current_energy = sum(0.5d0*g*height**2 + 0.5d0*height*(u**2 + v(:,1:size(height,2))**2))
+    if (reference_energy < 0.d0) then
+       reference_energy = current_energy
+       residual = 0.d0
+    else
+       residual = current_energy - reference_energy
+    end if
+  end function calc_energy_residual
+
+  !> Measure wave pattern energy as variance from zonal mean
+  !$FAD SKIP
+  function calc_wave_pattern(height) result(pattern)
+    real(dp), intent(in) :: height(:,:)
+    real(dp) :: pattern
+    real(dp), allocatable :: zonal_mean(:)
+    integer :: nx, ny, i, j
+    nx = size(height,1)
+    ny = size(height,2)
+    allocate(zonal_mean(ny))
+    zonal_mean = sum(height,dim=1)/nx
+    pattern = 0.d0
+    do j = 1, ny
+       do i = 1, nx
+          pattern = pattern + (height(i,j) - zonal_mean(j))**2
+       end do
+    end do
+    pattern = pattern / (nx*ny)
+    deallocate(zonal_mean)
+  end function calc_wave_pattern
 
   !> Compute L1, L2, and Linf error norms
   !$FAD CONSTANT_VARS: height_ana

--- a/src/common/io_module.f90
+++ b/src/common/io_module.f90
@@ -82,4 +82,14 @@ contains
     write(40,'(a,1x,e25.16)') 'MassResidual', mass_res
     close(40)
   end subroutine write_cost_log
+
+  !$FAD SKIP
+  subroutine write_cost_log2(mass_res, energy_res, wave)
+    real(dp), intent(in) :: mass_res, energy_res, wave
+    open(unit=40,file='cost.log',status='replace')
+    write(40,'(a,1x,e25.16)') 'MassResidual', mass_res
+    write(40,'(a,1x,e25.16)') 'EnergyResidual', energy_res
+    write(40,'(a,1x,e25.16)') 'WavePattern', wave
+    close(40)
+  end subroutine write_cost_log2
 end module io_module

--- a/src/common/variables_module.f90
+++ b/src/common/variables_module.f90
@@ -18,9 +18,10 @@ module variables_module
   real(dp), allocatable :: x(:), y(:)
   real(dp), allocatable :: h(:,:), hn(:,:), ha(:,:)
   real(dp), allocatable :: u(:,:), v(:,:)
+  real(dp), allocatable :: b(:,:)
   real(sp), allocatable :: hsp(:,:), usp(:,:), vsp(:,:)
 
-  !$FAD CONSTANT_VARS: x, y
+  !$FAD CONSTANT_VARS: x, y, b
   !$FAD CONSTANT_VARS: ha
   !$FAD CONSTANT_VARS: hsp, usp, vsp
 
@@ -31,6 +32,7 @@ contains
     allocate(x(nx), y(ny))
     allocate(h(nx,ny), hn(nx,ny), ha(nx,ny))
     allocate(u(nx,ny), v(nx,ny+1))
+    allocate(b(nx,ny))
     allocate(hsp(nx,ny), usp(nx,ny), vsp(nx,ny))
     do i=1,nx
        x(i) = (i-0.5d0)*dx
@@ -48,6 +50,7 @@ contains
     if (allocated(ha)) deallocate(ha)
     if (allocated(u)) deallocate(u)
     if (allocated(v)) deallocate(v)
+    if (allocated(b)) deallocate(b)
     if (allocated(hsp)) deallocate(hsp)
     if (allocated(usp)) deallocate(usp)
     if (allocated(vsp)) deallocate(vsp)

--- a/src/testcase5/shallow_water_test5.f90
+++ b/src/testcase5/shallow_water_test5.f90
@@ -1,0 +1,48 @@
+program shallow_water_test5
+  use constants_module, only: dp
+  use cost_module, only: calc_mass_residual, calc_energy_residual, calc_wave_pattern
+  use variables_module
+  use equations_module
+  use rk4_module
+  use io_module
+  implicit none
+
+  real(dp) :: t, mass_res, energy_res, wave
+  integer :: n
+  real(dp) :: un(nx,ny), vn(nx,ny+1)
+  character(len=256) :: carg
+
+  call init_variables()
+  call read_output_interval(output_interval)
+  call write_grid_params()
+  call init_topography(b, x, y)
+  if (command_argument_count() >= 2) then
+     call get_command_argument(2, carg)
+     call read_field(h, trim(carg))
+  else
+     h = h0 - b
+  end if
+  call velocity_field(u, v, x, y)
+  mass_res = calc_mass_residual(h)
+  energy_res = calc_energy_residual(h, u, v)
+  do n = 0, nsteps
+     t = n*dt
+     if (output_interval /= -1) then
+        if (output_interval == 0) then
+           if (n == nsteps) call write_snapshot(n, h, u, v)
+        else if (mod(n, output_interval) == 0) then
+           call write_snapshot(n, h, u, v)
+        end if
+     end if
+     if (n == nsteps) exit
+     call rk4_step(h, u, v, hn, un, vn)
+     h = hn
+     u = un
+     v = vn
+  end do
+  mass_res = calc_mass_residual(h)
+  energy_res = calc_energy_residual(h, u, v)
+  wave = calc_wave_pattern(h)
+  call write_cost_log2(mass_res, energy_res, wave)
+  call finalize_variables()
+end program shallow_water_test5

--- a/src/testcase5/shallow_water_test5_forward.f90
+++ b/src/testcase5/shallow_water_test5_forward.f90
@@ -1,0 +1,66 @@
+program shallow_water_test5_forward
+  use constants_module, only: dp
+  use cost_module, only: calc_wave_pattern, calc_mass_residual, calc_energy_residual
+  use cost_module_ad, only: calc_mass_residual_fwd_ad, calc_energy_residual_fwd_ad
+  use variables_module
+  use variables_module_ad
+  use equations_module
+  use equations_module_ad
+  use rk4_module
+  use rk4_module_ad
+  use io_module
+  implicit none
+
+  real(dp) :: t, mass_res, energy_res, wave
+  real(dp) :: mass_res_ad, energy_res_ad
+  integer :: n
+  character(len=256) :: carg
+  real(dp) :: un(nx,ny), vn(nx,ny+1)
+  real(dp) :: un_ad(nx,ny), vn_ad(nx,ny+1)
+
+  call init_variables()
+  call init_variables_fwd_ad()
+  call read_output_interval(output_interval)
+  call write_grid_params()
+  call init_topography(b, x, y)
+  if (command_argument_count() >= 2) then
+     call get_command_argument(2, carg)
+     call read_field(h, trim(carg))
+  else
+     h = h0 - b
+  end if
+  if (command_argument_count() >= 3) then
+     call get_command_argument(3, carg)
+     call read_field(h_ad, trim(carg))
+  else
+     h_ad = 0.d0
+     h_ad(nx/2, ny/2) = 1.d0
+  end if
+  u_ad = 0.d0
+  v_ad = 0.d0
+  call velocity_field(u, v, x, y)
+  mass_res = calc_mass_residual(h)
+  energy_res = calc_energy_residual(h, u, v)
+  do n = 0, nsteps
+     t = n*dt
+     if (output_interval /= -1) then
+        if (output_interval == 0) then
+           if (n == nsteps) call write_snapshot(n, h_ad, u, v)
+        else if (mod(n, output_interval) == 0) then
+           call write_snapshot(n, h_ad, u, v)
+        end if
+     end if
+     if (n == nsteps) exit
+     call rk4_step_fwd_ad(h, h_ad, u, u_ad, v, v_ad, hn, hn_ad, un, un_ad, vn, vn_ad)
+     h = hn; h_ad = hn_ad
+     u = un; u_ad = un_ad
+     v = vn; v_ad = vn_ad
+  end do
+  mass_res = calc_mass_residual(h)
+  call calc_mass_residual_fwd_ad(h, h_ad, mass_res, mass_res_ad)
+  call calc_energy_residual_fwd_ad(h, h_ad, u, u_ad, v, v_ad, energy_res, energy_res_ad)
+  wave = calc_wave_pattern(h)
+  call write_cost_log2(mass_res, energy_res, wave)
+  print *, energy_res_ad, mass_res_ad, 0.d0
+  call finalize_variables_fwd_ad()
+end program shallow_water_test5_forward

--- a/src/testcase5/shallow_water_test5_reverse.f90
+++ b/src/testcase5/shallow_water_test5_reverse.f90
@@ -1,0 +1,97 @@
+program shallow_water_test5_reverse
+  use constants_module, only: dp
+  use cost_module, only: calc_mass_residual, calc_energy_residual, calc_wave_pattern
+  use cost_module_ad, only: calc_mass_residual_rev_ad, calc_energy_residual_rev_ad
+  use variables_module
+  use variables_module_ad
+  use equations_module
+  use equations_module_ad
+  use rk4_module
+  use rk4_module_ad
+  use io_module
+  use io_module_ad
+  use fautodiff_stack
+  implicit none
+
+  real(dp) :: mass_res, energy_res, wave
+  real(dp) :: mass_res_ad, energy_res_ad
+  real(dp) :: grad_dot_d
+  integer :: n
+  character(len=256) :: carg
+  real(dp), allocatable :: d(:,:)
+  real(dp) :: un(nx,ny), vn(nx,ny+1)
+  real(dp) :: un_ad(nx,ny), vn_ad(nx,ny+1)
+
+  call init_variables()
+  call read_output_interval(output_interval)
+  call write_grid_params()
+  call init_topography(b, x, y)
+  if (command_argument_count() >= 2) then
+     call get_command_argument(2, carg)
+     call read_field(h, trim(carg))
+  else
+     h = h0 - b
+  end if
+  allocate(d(nx,ny))
+  if (command_argument_count() >= 3) then
+     call get_command_argument(3, carg)
+     call read_field(d, trim(carg))
+  else
+     d = 0.d0
+  end if
+
+  call velocity_field(u, v, x, y)
+  mass_res = calc_mass_residual(h)
+  energy_res = calc_energy_residual(h, u, v)
+  do n = 0, nsteps
+     call fautodiff_stack_push_r(h)
+     call fautodiff_stack_push_r(u)
+     call fautodiff_stack_push_r(v)
+     if (n == nsteps) exit
+     call rk4_step(h, u, v, hn, un, vn)
+     h = hn
+     u = un
+     v = vn
+  end do
+  wave = calc_wave_pattern(h)
+  mass_res = calc_mass_residual(h)
+  energy_res = calc_energy_residual(h, u, v)
+
+  call finalize_variables_rev_ad()
+
+  energy_res_ad = 1.d0
+  mass_res_ad = 0.d0
+  h_ad = 0.d0
+  u_ad = 0.d0
+  v_ad = 0.d0
+
+  call calc_mass_residual_rev_ad(h, h_ad, mass_res_ad)
+  call calc_energy_residual_rev_ad(h, h_ad, u, u_ad, v, v_ad, energy_res_ad)
+
+  do n = nsteps, 0, -1
+     call fautodiff_stack_pop_r(v)
+     call fautodiff_stack_pop_r(u)
+     call fautodiff_stack_pop_r(h)
+     if (n /= nsteps) then
+        hn_ad = h_ad
+        un_ad = u_ad
+        vn_ad = v_ad
+        h_ad = 0.d0
+        u_ad = 0.d0
+        v_ad = 0.d0
+        call rk4_step_rev_ad(h, h_ad, u, u_ad, v, v_ad, hn_ad, un_ad, vn_ad)
+     end if
+     if (output_interval /= -1) then
+        if (output_interval == 0) then
+           if (n == 0) call write_snapshot(n, h_ad, u, v)
+        else if (mod(n, output_interval) == 0) then
+           call write_snapshot(n, h_ad, u, v)
+        end if
+     end if
+  end do
+  grad_dot_d = sum(h_ad*d)
+  print *, sum(h_ad), minval(h_ad), maxval(h_ad)
+  print *, grad_dot_d
+  call init_variables_rev_ad()
+  call finalize_variables()
+end program shallow_water_test5_reverse

--- a/tests/adjoint_test5.py
+++ b/tests/adjoint_test5.py
@@ -1,0 +1,56 @@
+import numpy as np
+import subprocess
+from pathlib import Path
+
+
+def save_field(path, arr):
+    path = Path(path)
+    arr.ravel(order='F').astype(np.float64).tofile(path)
+
+
+def read_snapshot(path, nlon, nlat):
+    path = Path(path)
+    data = np.fromfile(path, dtype=np.float32, count=nlon*nlat)
+    return data.reshape((nlon, nlat), order='F').astype(np.float64)
+
+
+def main():
+    build_dir = Path(__file__).resolve().parents[1] / 'build'
+    subprocess.run(['make', 'shallow_water_test5_forward.out',
+                    'shallow_water_test5_reverse.out'],
+                   check=True, cwd=build_dir, capture_output=True)
+    exe_fwd = build_dir / 'shallow_water_test5_forward.out'
+    exe_rev = build_dir / 'shallow_water_test5_reverse.out'
+
+    nlon, nlat = 128, 64
+    rng = np.random.default_rng(0)
+    x = rng.standard_normal((nlon, nlat))
+    u = rng.standard_normal((nlon, nlat))
+    v = rng.standard_normal()
+
+    x_file = build_dir / 'x5.bin'
+    u_file = build_dir / 'u5.bin'
+    save_field(x_file, x)
+    save_field(u_file, u)
+
+    res = subprocess.run([
+        str(exe_fwd), '-1', str(x_file), str(u_file)
+    ], check=True, cwd=build_dir, capture_output=True, text=True)
+    Ju = float(res.stdout.strip().split()[0])
+
+    subprocess.run([
+        str(exe_rev), '0', str(x_file)
+    ], check=True, cwd=build_dir, capture_output=True, text=True)
+    g = read_snapshot(build_dir / 'snapshot_0000.bin', nlon, nlat)
+
+    JT_v = v * g
+    lhs = v * Ju
+    rhs = np.vdot(u.ravel(order='F'), JT_v.ravel(order='F'))
+    diff = abs(lhs - rhs)
+    tol = max(1e-12, 1e-6 * max(abs(lhs), abs(rhs)))
+    print(f"vTJu={lhs:.6e} uTJTv={rhs:.6e} diff={diff:.6e}")
+    assert diff < tol
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/taylor_test5.py
+++ b/tests/taylor_test5.py
@@ -1,0 +1,101 @@
+import numpy as np
+import subprocess
+from pathlib import Path
+
+
+def save_field(path, arr):
+    path = Path(path)
+    arr.ravel(order='F').astype(np.float64).tofile(path)
+
+
+def read_energy_cost(path):
+    path = Path(path)
+    with path.open() as f:
+        for line in f:
+            if line.startswith('EnergyResidual'):
+                return float(line.split()[1])
+    raise RuntimeError('EnergyResidual not found')
+
+
+def init_height(nlon, nlat):
+    radius = 6371220.0
+    h0 = 10000.0
+    h1 = 2000.0
+    Lx = 2.0 * np.pi * radius
+    Ly = np.pi * radius
+    dx = Lx / nlon
+    dy = Ly / nlat
+    x = (np.arange(nlon) + 0.5) * dx
+    y = (np.arange(nlat) + 0.5) * dy
+    x0 = 0.5 * Lx
+    y0 = 0.5 * Ly
+    r0 = radius / 4.0
+    b = np.zeros((nlon, nlat))
+    for j in range(nlat):
+        for i in range(nlon):
+            dist = np.hypot(x[i] - x0, y[j] - y0)
+            if dist < r0:
+                b[i, j] = h1 * (1.0 - dist / r0)
+    return h0 - b
+
+
+def main():
+    build_dir = Path(__file__).resolve().parents[1] / 'build'
+    subprocess.run([
+        'make',
+        'shallow_water_test5.out',
+        'shallow_water_test5_forward.out',
+        'shallow_water_test5_reverse.out',
+    ], check=True, cwd=build_dir, capture_output=True)
+    exe_base = build_dir / 'shallow_water_test5.out'
+    exe_fwd = build_dir / 'shallow_water_test5_forward.out'
+    exe_rev = build_dir / 'shallow_water_test5_reverse.out'
+
+    nlon, nlat = 128, 64
+    rng = np.random.default_rng(0)
+    x = init_height(nlon, nlat)
+    d = rng.standard_normal((nlon, nlat))
+
+    x_file = build_dir / 'x5_tay.bin'
+    d_file = build_dir / 'd5_tay.bin'
+    save_field(x_file, x)
+    save_field(d_file, d)
+
+    subprocess.run([str(exe_base), '0', str(x_file)], check=True, cwd=build_dir)
+    F0 = read_energy_cost(build_dir / 'cost.log')
+
+    eps_list = np.logspace(-1, -5, num=5)
+    diffs = []
+    for i, eps in enumerate(eps_list):
+        x_eps = x + eps * d
+        x_eps_file = build_dir / f'x5_eps_{i}.bin'
+        save_field(x_eps_file, x_eps)
+        subprocess.run([str(exe_base), '0', str(x_eps_file)], check=True, cwd=build_dir)
+        Fe = read_energy_cost(build_dir / 'cost.log')
+        diffs.append((Fe - F0) / eps)
+    diffs = np.array(diffs)
+
+    res = subprocess.run([str(exe_fwd), '0', str(x_file), str(d_file)],
+                         check=True, cwd=build_dir, capture_output=True, text=True)
+    energy_ad = float(res.stdout.strip().split()[0])
+
+    res = subprocess.run([str(exe_rev), '0', str(x_file), str(d_file)],
+                         check=True, cwd=build_dir, capture_output=True, text=True)
+    lines = res.stdout.strip().splitlines()
+    grad_dot_d = float(lines[-1].split()[0])
+
+    fwd_err = np.abs(energy_ad - diffs)
+    rev_err = np.abs(grad_dot_d - diffs)
+
+    for eps, diff, fe, re in zip(eps_list, diffs, fwd_err, rev_err):
+        print(f"eps={eps:.1e} diff={diff:.6e} fwd_err={fe:.6e} rev_err={re:.6e}")
+
+    np.savez(build_dir / 'taylor_test5_results.npz', eps=eps_list, diff=diffs,
+             fwd=fwd_err, rev=rev_err)
+
+    assert fwd_err[2] < fwd_err[0]
+    assert rev_err[2] < rev_err[0]
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- refactor cost module to source gravity constant from `variables_module` and skip AD generation for wave-pattern metric
- adjust forward and reverse solvers to compute wave metric without autodiff and log only energy residual derivatives
- add Taylor-test script for the conical topography solver validating forward/reverse AD against finite differences

## Testing
- `python tests/taylor_test5.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689447d879a8832db7e15e7145e7cedb