### PR TITLE
docs: document build and script-based tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,5 @@
 # AGENTS
 
-- Run tests with `pytest`.
-- The repository may clone the external library `fautodiff` into `scripts/fautodiff`. Its tests are unrelated to this project and should not be executed. `pytest` is configured to run only the tests under the `tests/` directory.
+- Build the project by running `make` inside the `build` directory.
+- Execute each script in the `tests/` directory and ensure they finish without error.
+- The repository may clone the external library `fautodiff` into `scripts/fautodiff`. Its tests are unrelated to this project and should not be executed.


### PR DESCRIPTION
## Summary
- document how to build the project with `make` and run test scripts

## Testing
- `cd build && make`
- `for script in tests/*.py; do echo "Running $script"; python $script; done`


------
https://chatgpt.com/codex/tasks/task_b_689478a348b0832d883bd609e8b2f746