### PR TITLE
Rename MPI size and rank variables to avoid intrinsic conflicts

### DIFF
--- a/src/common/mpi_decomp_module.f90
+++ b/src/common/mpi_decomp_module.f90
@@ -4,7 +4,7 @@ module mpi_decomp_module
   implicit none
   integer, parameter :: MPI_COMM_NULL = 0
   integer :: comm_cart = MPI_COMM_NULL
-  integer :: rank = -1, size = 0
+  integer :: mpi_rank = -1, mpi_size = 0
   integer :: dims(2) = 0, coords(2) = 0
   logical :: periods(2) = (/ .false., .false. /)
   integer :: nbr_west, nbr_east, nbr_south, nbr_north
@@ -14,13 +14,13 @@ contains
     integer, intent(in) :: nx_global, ny_global
     integer :: ierr
     call MPI_Init(ierr)
-    call MPI_Comm_rank(MPI_COMM_WORLD, rank, ierr)
-    call MPI_Comm_size(MPI_COMM_WORLD, size, ierr)
+    call MPI_Comm_rank(MPI_COMM_WORLD, mpi_rank, ierr)
+    call MPI_Comm_size(MPI_COMM_WORLD, mpi_size, ierr)
     dims = 0
-    call MPI_Dims_create(size, 2, dims, ierr)
+    call MPI_Dims_create(mpi_size, 2, dims, ierr)
     periods = (/ .true., .false. /)
     call MPI_Cart_create(MPI_COMM_WORLD, 2, dims, periods, .false., comm_cart, ierr)
-    call MPI_Cart_coords(comm_cart, rank, 2, coords, ierr)
+    call MPI_Cart_coords(comm_cart, mpi_rank, 2, coords, ierr)
     istart = block_start(coords(1), dims(1), nx_global)
     iend   = block_end(coords(1), dims(1), nx_global)
     jstart = block_start(coords(2), dims(2), ny_global)

--- a/src/testcase2/shallow_water_test2_reverse.f90
+++ b/src/testcase2/shallow_water_test2_reverse.f90
@@ -81,7 +81,7 @@ program shallow_water_test2_reverse
         end if
      end if
   end do
-  call geostrophic_velocity_rev_ad(u_ad, v_ad, h_ad)
+  call geostrophic_velocity_rev_ad(u_ad, v_ad, h, h_ad)
   call exchange_halo_x(h_ad)
   if (output_interval == 0) then
      call write_snapshot(0, h_ad, u_ad, v_ad)

--- a/src/testcase5/shallow_water_test5_reverse.f90
+++ b/src/testcase5/shallow_water_test5_reverse.f90
@@ -93,7 +93,7 @@ program shallow_water_test5_reverse
         end if
      end if
   end do
-  call geostrophic_velocity_rev_ad(u_ad, v_ad, h_ad)
+  call geostrophic_velocity_rev_ad(u_ad, v_ad, h, h_ad)
   call exchange_halo_x(h_ad)
   if (output_interval == 0) then
      call write_snapshot(0, h_ad, u_ad, v_ad)


### PR DESCRIPTION
## Summary
- Rename `rank` and `size` variables to `mpi_rank` and `mpi_size` to prevent collisions with Fortran intrinsics.
- Pass forward state `h` to `geostrophic_velocity_rev_ad` in reverse-mode test drivers.

## Testing
- `make`
- `python tests/adjoint_test1.py` *(fails: exit status 139)*
- `python tests/adjoint_test2.py` *(fails: exit status 134)*
- `python tests/adjoint_test5.py` *(fails: exit status 134)*
- `python tests/taylor_test1.py` *(fails: exit status 134)*
- `python tests/taylor_test2.py` *(fails: exit status 134)*
- `python tests/taylor_test5.py` *(fails: exit status 136)*

------
https://chatgpt.com/codex/tasks/task_b_68a13fdfd5b0832da2c7500869a13bdb