### PR TITLE
Use independent MPI I/O for field reads

### DIFF
--- a/src/common/io_module.f90
+++ b/src/common/io_module.f90
@@ -36,8 +36,8 @@ contains
 
     do j = 0, nj-1
        offset = int(((jstart - 1 + j) * nx + (istart - 1)), MPI_OFFSET_KIND) * 8_MPI_OFFSET_KIND
-       call MPI_File_read_at_all(fh, offset, buf, ni, MPI_DOUBLE_PRECISION, MPI_STATUS_IGNORE, ierr)
-       if (ierr /= MPI_SUCCESS) stop 'MPI_File_read_at_all failed'
+       call MPI_File_read_at(fh, offset, buf, ni, MPI_DOUBLE_PRECISION, MPI_STATUS_IGNORE, ierr)
+       if (ierr /= MPI_SUCCESS) stop 'MPI_File_read_at failed'
        field(istart:iend, jstart + j) = buf
     end do
 


### PR DESCRIPTION
## Summary
- handle uneven `nj` across ranks by switching `read_field` to `MPI_File_read_at`

## Testing
- `make`
- `python tests/taylor_test1.py` *(fails: Process abort signal)*
- `python tests/adjoint_test1.py` *(fails: exit status 139)*

------
https://chatgpt.com/codex/tasks/task_b_68a4150b7b0c832dbea46de125911fe5