### PR TITLE
Ensure positive height fields in tests

### DIFF
--- a/tests/adjoint_test1.py
+++ b/tests/adjoint_test1.py
@@ -2,14 +2,31 @@ import numpy as np
 import subprocess
 from pathlib import Path
 
+
 def save_field(path, arr):
     path = Path(path)
     arr.ravel(order='F').astype(np.float64).tofile(path)
+
 
 def read_snapshot(path, nlon, nlat):
     path = Path(path)
     data = np.fromfile(path, dtype=np.float32, count=nlon*nlat)
     return data.reshape((nlon, nlat), order='F').astype(np.float64)
+
+
+def geostrophic_height(nx, ny):
+    pi = np.pi
+    radius = 6371220.0
+    g = 9.80616
+    day = 86400.0
+    omega = 2.0 * pi / (12.0 * day)
+    h0 = 10000.0
+    u0 = 20.0
+    dlat = pi / ny
+    lat = -pi/2 + (np.arange(ny) + 0.5) * dlat
+    coeff = radius * omega * u0 / g
+    hlat = h0 + coeff * np.sin(lat) ** 2
+    return np.repeat(hlat[np.newaxis, :], nx, axis=0)
 
 def main():
     build_dir = Path(__file__).resolve().parents[1] / 'build'
@@ -18,7 +35,7 @@ def main():
 
     nlon, nlat = 128, 64
     rng = np.random.default_rng(0)
-    x = rng.standard_normal((nlon, nlat))
+    x = geostrophic_height(nlon, nlat)
     u = rng.standard_normal((nlon, nlat))
     v = rng.standard_normal()
 

--- a/tests/taylor_test1.py
+++ b/tests/taylor_test1.py
@@ -2,9 +2,11 @@ import numpy as np
 import subprocess
 from pathlib import Path
 
+
 def save_field(path, arr):
     path = Path(path)
     arr.ravel(order='F').astype(np.float64).tofile(path)
+
 
 def read_cost(path):
     path = Path(path)
@@ -14,6 +16,21 @@ def read_cost(path):
                 return float(line.split()[1])
     raise RuntimeError('MSE not found')
 
+
+def geostrophic_height(nx, ny):
+    pi = np.pi
+    radius = 6371220.0
+    g = 9.80616
+    day = 86400.0
+    omega = 2.0 * pi / (12.0 * day)
+    h0 = 10000.0
+    u0 = 20.0
+    dlat = pi / ny
+    lat = -pi/2 + (np.arange(ny) + 0.5) * dlat
+    coeff = radius * omega * u0 / g
+    hlat = h0 + coeff * np.sin(lat) ** 2
+    return np.repeat(hlat[np.newaxis, :], nx, axis=0)
+
 def main():
     build_dir = Path(__file__).resolve().parents[1] / 'build'
     exe_base = build_dir / 'shallow_water_test1.out'
@@ -22,7 +39,7 @@ def main():
 
     nx, ny = 128, 64
     rng = np.random.default_rng(0)
-    x = rng.standard_normal((nx, ny))
+    x = geostrophic_height(nx, ny)
     d = rng.standard_normal((nx, ny))
 
     x_file = build_dir / 'x.bin'


### PR DESCRIPTION
## Summary
- Use geostrophic height to initialize test fields so that generated height data is always non-negative

## Testing
- `make`
- `python tests/adjoint_test1.py` *(fails: mpirun exited with status 134)*
- `python tests/adjoint_test2.py` *(fails: mpirun exited with status 134)*
- `python tests/adjoint_test5.py` *(fails: mpirun exited with status 134)*
- `python tests/taylor_test1.py` *(fails: mpirun aborted with malloc/tcache error)*
- `python tests/taylor_test2.py` *(fails: Fortran runtime index bounds error)*
- `python tests/taylor_test5.py` *(fails: Fortran runtime index bounds error)*

------
https://chatgpt.com/codex/tasks/task_b_68a41a2a8a28832d8024e0e8a8b09d64