### PR TITLE
Rename halo exchange and pack data before MPI

### DIFF
--- a/src/common/equations_module.f90
+++ b/src/common/equations_module.f90
@@ -1,7 +1,7 @@
 module equations_module
   use constants_module, only: dp
   use variables_module, only: nx, ny, Lx, Ly, dx, dy, g, radius, u0, f0, h0, h1, pi, b, &
-                               ihalo, is, ie, js, je, exchange_halo_x
+                               ihalo, is, ie, js, je, exchange_halo
   implicit none
 contains
 
@@ -30,7 +30,7 @@ contains
        end do
     end do
     !$omp end parallel do
-    call exchange_halo_x(h)
+    call exchange_halo(h)
   end subroutine init_height
 
   !$FAD SKIP
@@ -49,8 +49,8 @@ contains
     !$omp parallel workshare
     v(:,:) = 0.d0
     !$omp end parallel workshare
-    call exchange_halo_x(u)
-    call exchange_halo_x(v)
+    call exchange_halo(u)
+    call exchange_halo(v)
   end subroutine velocity_field
 
   !$FAD SKIP
@@ -75,7 +75,7 @@ contains
        end do
     end do
     !$omp end parallel do
-    call exchange_halo_x(b)
+    call exchange_halo(b)
   end subroutine init_topography
 
   !$FAD CONSTANT_VARS: y
@@ -92,7 +92,7 @@ contains
        end do
     end do
     !$omp end parallel do
-    call exchange_halo_x(h)
+    call exchange_halo(h)
   end subroutine init_geostrophic_height
 
   subroutine geostrophic_velocity(u, v, h)
@@ -118,8 +118,8 @@ contains
        end do
     end do
     !$omp end parallel do
-    call exchange_halo_x(u)
-    call exchange_halo_x(v)
+    call exchange_halo(u)
+    call exchange_halo(v)
     if (jstart == 1) then
        v(:,1) = 0.0_dp
     end if

--- a/src/common/io_module.f90
+++ b/src/common/io_module.f90
@@ -1,7 +1,7 @@
 module io_module
   use constants_module, only: dp, sp
   use variables_module, only: nx, ny, day, pi, h, u, v, &
-                              ihalo, is, ie, js, je, exchange_halo_x
+                              ihalo, is, ie, js, je, exchange_halo
   implicit none
 contains
 
@@ -43,7 +43,7 @@ contains
 
     call MPI_File_close(fh, ierr)
     deallocate(buf)
-    call exchange_halo_x(field)
+    call exchange_halo(field)
   end subroutine read_field
 
   !$FAD SKIP

--- a/src/common/rk4_module.f90
+++ b/src/common/rk4_module.f90
@@ -1,6 +1,6 @@
 module rk4_module
   use constants_module, only: dp
-  use variables_module, only: nx, ny, dt, ihalo, is, ie, js, je, exchange_halo_x
+  use variables_module, only: nx, ny, dt, ihalo, is, ie, js, je, exchange_halo
   use equations_module, only: rhs
   use mpi_decomp_module, only: istart, iend, jstart, jend
   implicit none
@@ -21,20 +21,20 @@ contains
     if (skip_momentum) then
        call rhs(h, u, v, k1h, k1u, k1v, no_momentum_tendency=.true.)
        htmp(istart:iend,jstart:jend) = h(istart:iend,jstart:jend) + 0.5d0*dt*k1h(istart:iend,jstart:jend)
-       call exchange_halo_x(htmp)
+       call exchange_halo(htmp)
        call rhs(htmp, u, v, k2h, k2u, k2v, no_momentum_tendency=.true.)
        htmp(istart:iend,jstart:jend) = h(istart:iend,jstart:jend) + 0.5d0*dt*k2h(istart:iend,jstart:jend)
-       call exchange_halo_x(htmp)
+       call exchange_halo(htmp)
        call rhs(htmp, u, v, k3h, k3u, k3v, no_momentum_tendency=.true.)
        htmp(istart:iend,jstart:jend) = h(istart:iend,jstart:jend) + dt*k3h(istart:iend,jstart:jend)
-       call exchange_halo_x(htmp)
+       call exchange_halo(htmp)
        call rhs(htmp, u, v, k4h, k4u, k4v, no_momentum_tendency=.true.)
        hn(istart:iend,jstart:jend) = h(istart:iend,jstart:jend) + dt*(k1h(istart:iend,jstart:jend) + 2.d0*k2h(istart:iend,jstart:jend) + 2.d0*k3h(istart:iend,jstart:jend) + k4h(istart:iend,jstart:jend))/6.d0
        un(istart:iend,jstart:jend) = u(istart:iend,jstart:jend)
        vn(istart:iend,jstart:jend) = v(istart:iend,jstart:jend)
-       call exchange_halo_x(hn)
-       call exchange_halo_x(un)
-       call exchange_halo_x(vn)
+       call exchange_halo(hn)
+       call exchange_halo(un)
+       call exchange_halo(vn)
        return
     end if
 
@@ -42,30 +42,30 @@ contains
     htmp(istart:iend,jstart:jend) = h(istart:iend,jstart:jend) + 0.5d0*dt*k1h(istart:iend,jstart:jend)
     utmp(istart:iend,jstart:jend) = u(istart:iend,jstart:jend) + 0.5d0*dt*k1u(istart:iend,jstart:jend)
     vtmp(istart:iend,jstart:jend) = v(istart:iend,jstart:jend) + 0.5d0*dt*k1v(istart:iend,jstart:jend)
-    call exchange_halo_x(htmp)
-    call exchange_halo_x(utmp)
-    call exchange_halo_x(vtmp)
+    call exchange_halo(htmp)
+    call exchange_halo(utmp)
+    call exchange_halo(vtmp)
     call rhs(htmp, utmp, vtmp, k2h, k2u, k2v, no_momentum_tendency=.false.)
     htmp(istart:iend,jstart:jend) = h(istart:iend,jstart:jend) + 0.5d0*dt*k2h(istart:iend,jstart:jend)
     utmp(istart:iend,jstart:jend) = u(istart:iend,jstart:jend) + 0.5d0*dt*k2u(istart:iend,jstart:jend)
     vtmp(istart:iend,jstart:jend) = v(istart:iend,jstart:jend) + 0.5d0*dt*k2v(istart:iend,jstart:jend)
-    call exchange_halo_x(htmp)
-    call exchange_halo_x(utmp)
-    call exchange_halo_x(vtmp)
+    call exchange_halo(htmp)
+    call exchange_halo(utmp)
+    call exchange_halo(vtmp)
     call rhs(htmp, utmp, vtmp, k3h, k3u, k3v, no_momentum_tendency=.false.)
     htmp(istart:iend,jstart:jend) = h(istart:iend,jstart:jend) + dt*k3h(istart:iend,jstart:jend)
     utmp(istart:iend,jstart:jend) = u(istart:iend,jstart:jend) + dt*k3u(istart:iend,jstart:jend)
     vtmp(istart:iend,jstart:jend) = v(istart:iend,jstart:jend) + dt*k3v(istart:iend,jstart:jend)
-    call exchange_halo_x(htmp)
-    call exchange_halo_x(utmp)
-    call exchange_halo_x(vtmp)
+    call exchange_halo(htmp)
+    call exchange_halo(utmp)
+    call exchange_halo(vtmp)
     call rhs(htmp, utmp, vtmp, k4h, k4u, k4v, no_momentum_tendency=.false.)
     hn(istart:iend,jstart:jend) = h(istart:iend,jstart:jend) + dt*(k1h(istart:iend,jstart:jend) + 2.d0*k2h(istart:iend,jstart:jend) + 2.d0*k3h(istart:iend,jstart:jend) + k4h(istart:iend,jstart:jend))/6.d0
     un(istart:iend,jstart:jend) = u(istart:iend,jstart:jend) + dt*(k1u(istart:iend,jstart:jend) + 2.d0*k2u(istart:iend,jstart:jend) + 2.d0*k3u(istart:iend,jstart:jend) + k4u(istart:iend,jstart:jend))/6.d0
     vn(istart:iend,jstart:jend) = v(istart:iend,jstart:jend) + dt*(k1v(istart:iend,jstart:jend) + 2.d0*k2v(istart:iend,jstart:jend) + 2.d0*k3v(istart:iend,jstart:jend) + k4v(istart:iend,jstart:jend))/6.d0
-    call exchange_halo_x(hn)
-    call exchange_halo_x(un)
-    call exchange_halo_x(vn)
+    call exchange_halo(hn)
+    call exchange_halo(un)
+    call exchange_halo(vn)
   end subroutine rk4_step
 
 end module rk4_module

--- a/src/common/variables_module.f90
+++ b/src/common/variables_module.f90
@@ -84,25 +84,38 @@ contains
     if (allocated(b)) deallocate(b)
   end subroutine finalize_variables
 
-  subroutine exchange_halo_x(field)
+  subroutine exchange_halo(field)
     use mpi_decomp_module, only : &
       comm_cart, nbr_west, nbr_east, nbr_south, nbr_north, &
       istart, iend, jstart, jend
     use mpi
     real(dp), intent(inout) :: field(is:,js:)
-    integer :: ierr, cntx, cnty
+    integer :: ierr, cntx, cnty, nx_loc, ny_loc
     integer :: requests(8)
-    real(dp) :: recvbuf(ihalo,jstart:jend,2)
+    real(dp), allocatable :: recvbuf(:,:,:)
+    real(dp), allocatable :: sendbuf(:,:,:)
 
-    cntx = (iend - istart + 1) * ihalo
-    cnty = (jend - jstart + 1) * ihalo
+    nx_loc = iend - istart + 1
+    ny_loc = jend - jstart + 1
+    cntx = nx_loc * ihalo
+    cnty = ny_loc * ihalo
+
+    allocate(recvbuf(ihalo, ny_loc, 2))
+    allocate(sendbuf(ihalo, ny_loc, 2))
+
+    if (nbr_west /= MPI_PROC_NULL) then
+      sendbuf(:,:,1) = field(istart:istart+ihalo-1, jstart:jend)
+    end if
+    if (nbr_east /= MPI_PROC_NULL) then
+      sendbuf(:,:,2) = field(iend-ihalo+1:iend,    jstart:jend)
+    end if
 
     call MPI_Irecv(recvbuf(:,:,1),                 cnty, MPI_DOUBLE_PRECISION, nbr_west,  0, comm_cart, requests(1), ierr)
     call MPI_Irecv(recvbuf(:,:,2),                 cnty, MPI_DOUBLE_PRECISION, nbr_east,  1, comm_cart, requests(2), ierr)
     call MPI_Irecv(field(istart:iend,js:jstart-1), cntx, MPI_DOUBLE_PRECISION, nbr_south, 2, comm_cart, requests(3), ierr)
     call MPI_Irecv(field(istart:iend,jend+1:je),   cntx, MPI_DOUBLE_PRECISION, nbr_north, 3, comm_cart, requests(4), ierr)
-    call MPI_Isend(field(iend-ihalo+1:iend,jstart:jend),     cnty, MPI_DOUBLE_PRECISION, nbr_east,  0, comm_cart, requests(5), ierr)
-    call MPI_Isend(field(istart:istart+ihalo-1,jstart:jend), cnty, MPI_DOUBLE_PRECISION, nbr_west,  1, comm_cart, requests(6), ierr)
+    call MPI_Isend(sendbuf(:,:,2),                 cnty, MPI_DOUBLE_PRECISION, nbr_east,  0, comm_cart, requests(5), ierr)
+    call MPI_Isend(sendbuf(:,:,1),                 cnty, MPI_DOUBLE_PRECISION, nbr_west,  1, comm_cart, requests(6), ierr)
     call MPI_Isend(field(istart:iend,jend-ihalo+1:jend),     cntx, MPI_DOUBLE_PRECISION, nbr_north, 2, comm_cart, requests(7), ierr)
     call MPI_Isend(field(istart:iend,jstart:jstart+ihalo-1), cntx, MPI_DOUBLE_PRECISION, nbr_south, 3, comm_cart, requests(8), ierr)
     call MPI_Waitall(8, requests, MPI_STATUSES_IGNORE, ierr)
@@ -112,7 +125,8 @@ contains
     if (nbr_east /= MPI_PROC_NULL) then
       field(iend+1:ie,jstart:jend) = recvbuf(:,:,2)
     end if
-  end subroutine exchange_halo_x
+    deallocate(recvbuf, sendbuf)
+  end subroutine exchange_halo
 
   subroutine exchange_halo_x_1d(field)
     use mpi_decomp_module, only : &

--- a/src/testcase1/shallow_water_test1_reverse.f90
+++ b/src/testcase1/shallow_water_test1_reverse.f90
@@ -89,7 +89,7 @@ program shallow_water_test1_reverse
         end if
      end if
   end do
-  call exchange_halo_x(h_ad)
+  call exchange_halo(h_ad)
   if (output_interval == 0) then
      call write_snapshot(0, h_ad, u_ad, v_ad)
   end if

--- a/src/testcase2/shallow_water_test2_reverse.f90
+++ b/src/testcase2/shallow_water_test2_reverse.f90
@@ -87,7 +87,7 @@ program shallow_water_test2_reverse
      end if
   end do
   call geostrophic_velocity_rev_ad(u_ad, v_ad, h_ad)
-  call exchange_halo_x(h_ad)
+  call exchange_halo(h_ad)
   if (output_interval == 0) then
      call write_snapshot(0, h_ad, u_ad, v_ad)
   end if

--- a/src/testcase5/shallow_water_test5_reverse.f90
+++ b/src/testcase5/shallow_water_test5_reverse.f90
@@ -99,7 +99,7 @@ program shallow_water_test5_reverse
      end if
   end do
   call geostrophic_velocity_rev_ad(u_ad, v_ad, h_ad)
-  call exchange_halo_x(h_ad)
+  call exchange_halo(h_ad)
   if (output_interval == 0) then
      call write_snapshot(0, h_ad, u_ad, v_ad)
   end if


### PR DESCRIPTION
## Summary
- rename `exchange_halo_x` to `exchange_halo`
- pack east/west halo data into contiguous buffers before MPI transfer
- guard halo packing when MPI neighbor is absent
- update modules and tests to use new `exchange_halo` routine

## Testing
- `python tests/adjoint_test1.py` *(fails: Command '['mpirun', '--allow-run-as-root', '-n', '4', '/workspace/shallow_water_adjoint/build/shallow_water_test1_forward.out', '-1', '/workspace/shallow_water_adjoint/build/x.bin', '/workspace/shallow_water_adjoint/build/u.bin']' returned non-zero exit status 134)*
- `python tests/adjoint_test2.py` *(fails: Command '['mpirun', '--allow-run-as-root', '-n', '4', '/workspace/shallow_water_adjoint/build/shallow_water_test2_forward.out', '-1', '/workspace/shallow_water_adjoint/build/x2.bin', '/workspace/shallow_water_adjoint/build/u2.bin']' returned non-zero exit status 139)*
- `python tests/adjoint_test5.py` *(fails: Command '['mpirun', '--allow-run-as-root', '-n', '4', '/workspace/shallow_water_adjoint/build/shallow_water_test5_forward.out', '-1', '/workspace/shallow_water_adjoint/build/x5.bin', '/workspace/shallow_water_adjoint/build/u5.bin']' returned non-zero exit status 134)*
- `python tests/taylor_test1.py` *(fails: Command '['mpirun', '--allow-run-as-root', '-n', '4', '/workspace/shallow_water_adjoint/build/shallow_water_test1.out', '0', '/workspace/shallow_water_adjoint/build/x.bin']' returned non-zero exit status 134)*
- `python tests/taylor_test2.py` *(fails: Command '['mpirun', '--allow-run-as-root', '-n', '4', '/workspace/shallow_water_adjoint/build/shallow_water_test2.out', '0', '/workspace/shallow_water_adjoint/build/x2.bin']' returned non-zero exit status 2)*
- `python tests/taylor_test5.py` *(fails: Command '['mpirun', '--allow-run-as-root', '-n', '4', '/workspace/shallow_water_adjoint/build/shallow_water_test5.out', '0', '/workspace/shallow_water_adjoint/build/x5_tay.bin']' returned non-zero exit status 2)*

------
https://chatgpt.com/codex/tasks/task_b_68a4286ce4c8832d93811f365da6f704