### PR TITLE
Use local i-range in meridional momentum loop

### DIFF
--- a/src/common/equations_module.f90
+++ b/src/common/equations_module.f90
@@ -212,7 +212,9 @@ contains
     do j = max(jstart, 2), jend
        jp1 = j+1
        jm1 = j-1
-       do i=1,nx
+       ! Iterate over the local i-range for MPI domain decomposition.
+       ! Halo exchanges ensure neighbor access (i±1) is valid.
+       do i = istart, iend
           h_n = h(i,j) + b(i,j)
           h_s = h(i,jm1) + b(i,jm1)
           u_avg = 0.25d0*(u(i,jm1) + u(i+1,jm1) + u(i,j) + u(i+1,j))


### PR DESCRIPTION
## Summary
- restrict meridional momentum loop to MPI-local i-range
- clarify MPI domain decomposition in comments

## Testing
- `make`
- `python tests/taylor_test1.py` *(fails: invalid pointer in rk4_step)*
- `python tests/adjoint_test1.py` *(fails: CalledProcessError exit status 7)*
- `python tests/taylor_test2.py` *(fails: floating point exception in equations_module)*
- `python tests/adjoint_test2.py` *(fails: CalledProcessError exit status 7)*
- `python tests/taylor_test5.py` *(fails: floating point exception in equations_module)*
- `python tests/adjoint_test5.py` *(fails: CalledProcessError exit status 7)*

------
https://chatgpt.com/codex/tasks/task_b_68a46878ae28832d81ec163a0915ad33