### PR TITLE
Restrict forward adjoint initialization to local MPI domain

### DIFF
--- a/src/testcase1/shallow_water_test1_forward.f90
+++ b/src/testcase1/shallow_water_test1_forward.f90
@@ -13,7 +13,7 @@ program shallow_water_test1_forward
 
   real(dp) :: t, maxerr, l1err, l2err, mse, mass_res
   real(dp) :: t_ad, maxerr_ad, l1err_ad, l2err_ad, mse_ad, mass_res_ad
-  integer :: n
+  integer :: n, i1, i2, j1, j2
   character(len=256) :: carg
   real(dp), allocatable :: un(:,:), vn(:,:)
   real(dp), allocatable :: un_ad(:,:), vn_ad(:,:)
@@ -38,8 +38,16 @@ program shallow_water_test1_forward
      call read_field(h_ad, trim(carg))
   else
      h_ad(:,:) = 0.0_dp
-     h_ad(nx/2-1:nx/2+2,ny/2-1:ny/2+2) = 0.5_dp
-     h_ad(nx/2:nx/2+1,ny/2:ny/2+1) = 1.0_dp
+     i1 = max(nx/2-1, is)
+     i2 = min(nx/2+2, ie)
+     j1 = max(ny/2-1, js)
+     j2 = min(ny/2+2, je)
+     if (i1 <= i2 .and. j1 <= j2) h_ad(i1:i2, j1:j2) = 0.5_dp
+     i1 = max(nx/2, is)
+     i2 = min(nx/2+1, ie)
+     j1 = max(ny/2, js)
+     j2 = min(ny/2+1, je)
+     if (i1 <= i2 .and. j1 <= j2) h_ad(i1:i2, j1:j2) = 1.0_dp
   end if
   u_ad = 0.0_dp
   v_ad = 0.0_dp

--- a/src/testcase2/shallow_water_test2_forward.f90
+++ b/src/testcase2/shallow_water_test2_forward.f90
@@ -14,7 +14,7 @@ program shallow_water_test2_forward
 
   real(dp) :: t, mse, mass_res
   real(dp) :: t_ad, mse_ad, mass_res_ad
-  integer :: n
+  integer :: n, i1, i2, j1, j2
   character(len=256) :: carg
   real(dp), allocatable :: un(:,:), vn(:,:)
   real(dp), allocatable :: un_ad(:,:), vn_ad(:,:)
@@ -42,8 +42,16 @@ program shallow_water_test2_forward
      call read_field(h_ad, trim(carg))
   else
      h_ad = 0.0_dp
-     h_ad(nx/2-1:nx/2+2, ny/2-1:ny/2+2) = 0.5_dp
-     h_ad(nx/2:nx/2+1, ny/2:ny/2+1) = 1.0_dp
+     i1 = max(nx/2-1, is)
+     i2 = min(nx/2+2, ie)
+     j1 = max(ny/2-1, js)
+     j2 = min(ny/2+2, je)
+     if (i1 <= i2 .and. j1 <= j2) h_ad(i1:i2, j1:j2) = 0.5_dp
+     i1 = max(nx/2, is)
+     i2 = min(nx/2+1, ie)
+     j1 = max(ny/2, js)
+     j2 = min(ny/2+1, je)
+     if (i1 <= i2 .and. j1 <= j2) h_ad(i1:i2, j1:j2) = 1.0_dp
   end if
   call geostrophic_velocity_fwd_ad(u, u_ad, v, v_ad, h, h_ad)
   do n = 0, nsteps

--- a/src/testcase5/shallow_water_test5_forward.f90
+++ b/src/testcase5/shallow_water_test5_forward.f90
@@ -14,7 +14,7 @@ program shallow_water_test5_forward
 
   real(dp) :: t, mass_res, energy_res, wave
   real(dp) :: mass_res_ad, energy_res_ad
-  integer :: n
+  integer :: n, i1, i2, j1, j2
   character(len=256) :: carg
   real(dp), allocatable :: un(:,:), vn(:,:)
   real(dp), allocatable :: un_ad(:,:), vn_ad(:,:)
@@ -42,8 +42,16 @@ program shallow_water_test5_forward
      call read_field(h_ad, trim(carg))
   else
      h_ad = 0.0_dp
-     h_ad(nx/4-1:nx/4+2, ny*3/4-1:ny*3/4+2) = 0.5_dp
-     h_ad(nx/4:nx/4+1, ny*3/4:ny*3/4+1) = 1.0_dp
+     i1 = max(nx/4-1, is)
+     i2 = min(nx/4+2, ie)
+     j1 = max(ny*3/4-1, js)
+     j2 = min(ny*3/4+2, je)
+     if (i1 <= i2 .and. j1 <= j2) h_ad(i1:i2, j1:j2) = 0.5_dp
+     i1 = max(nx/4, is)
+     i2 = min(nx/4+1, ie)
+     j1 = max(ny*3/4, js)
+     j2 = min(ny*3/4+1, je)
+     if (i1 <= i2 .and. j1 <= j2) h_ad(i1:i2, j1:j2) = 1.0_dp
   end if
   call geostrophic_velocity_fwd_ad(u, u_ad, v, v_ad, hgeo, h_ad)
   h = hgeo - b


### PR DESCRIPTION
## Summary
- guard adjoint height initialization to only update each rank's local grid for forward tests 1, 2 and 5
- avoid out-of-domain accesses when seeding central perturbation patches

## Testing
- `make`
- `python tests/adjoint_test1.py` *(fails: MPI_ERR_REQUEST: invalid request)*
- `python tests/adjoint_test2.py` *(fails: MPI_ERR_REQUEST: invalid request)*
- `python tests/adjoint_test5.py` *(fails: MPI_ERR_REQUEST: invalid request)*
- `python tests/taylor_test1.py` *(fails: subprocess interrupted after hang)*
- `python tests/taylor_test2.py` *(fails: Floating-point exception)*
- `python tests/taylor_test5.py` *(fails: Floating-point exception)*

------
https://chatgpt.com/codex/tasks/task_b_68a488b099d8832da53a4457a189ba25