### PR TITLE
Ensure fautodiff update precedes AD generation

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -62,7 +62,7 @@ mpi_ad.o: mpi_ad.f90
 %.o: %.f90
 >$(FC) $(FFLAGS) -c $< -o $@
 
-%_ad.f90: %.f90 $(FAUTODIFF_SRC)
+%_ad.f90: %.f90 $(FAUTODIFF_SRC) | update_fautodiff
 >../scripts/fautodiff/bin/fautodiff $< -I . -M . -o $@
 
 ad: update_fautodiff
@@ -71,7 +71,7 @@ update_fautodiff:
 >../scripts/setup_fautodiff.sh
 >../scripts/copy_fautodiff_modules.sh
 
-$(FAUTODIFF_SRC):
+$(FAUTODIFF_SRC): | update_fautodiff
 >../scripts/copy_fautodiff_modules.sh
 
 clean:


### PR DESCRIPTION
## Summary
- prevent race condition where `_ad.f90` files could be created before `fautodiff` modules are updated
- enforce `update_fautodiff` runs before copying modules and generating AD sources

## Testing
- `make -j4`
- ⚠️ `python tests/adjoint_test1.py` *(hangs; interrupted)*
- ⚠️ `python tests/taylor_test1.py` *(hangs; interrupted)*

------
https://chatgpt.com/codex/tasks/task_b_68c82137ccdc832db3486eeea51eaaa3